### PR TITLE
Fix build script on macOS

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -98,8 +98,7 @@ const main = () => {
     '--',
     // Arguments to lerna run in root
     '--loglevel=warn',
-    '--scope',
-    lernaScope,
+    `--scope=${lernaScope}`,
     // Arguments to npm run in each package
     '--',
     '-s'


### PR DESCRIPTION
Fixes #6 

---

The generated build command previously became something like

```
... --scope @condict/{a,b,c} ...
```

which the shell may expand to

```
... --scope @condict/a @condict/b @condict/c ...
```

at which point Lerna complains that `@condict/b` and `@condict/c` are
unknown CLI arguments. By instead passing the argument as
`--scope=@condict/{a,b,c}`, the shell should expand it to

```
... --scope=@condict/a --scope=@condict/b --scope=@condict/c ...
```

which ought to work correctly.