### PR TITLE
Searchable server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ In lieu of a proper timeline or to-do list, here are some of the features that a
   - [x] Including the ability to add inflected words to the dictionary, so that _birds_ can be shown as "_plural of **bird**_".
 * [ ] **Word etymology,** both free-form – e.g. "Misinterpretation of _acorn_ as _egg_ + _corn_" – and simple combinations of other words – "_snow_ + _man_".
   - [ ] Including showing derived terms under any dictionary word. Under _snow_, you'd be able to find _snowman_.
-* [ ] **Search and filtering options,** naturally.
+* [x] **Search and filtering options,** naturally.
 * [ ] **Sample texts,** with [interlinear glosses][interlinear], which get automatically linked to and shown under the words used therein.
 * [x] **Tags,** mainly for thematic grouping, such as _food_, _colours_, _emotions_.
 * And more in the future!

--- a/graphql-schema/language.graphql
+++ b/graphql-schema/language.graphql
@@ -69,6 +69,41 @@ type Language {
   is always paginated. If provided, `page.perPage` cannot exceed 200.
   """
   tags(page: PageParams): TagConnection!
+
+  """
+  Searches the language. This field behaves like `Query.search` with an implicit
+  language filter. See that field for more documentation and examples.
+
+  The following are equivalent:
+
+  ```graphql
+  query($language: LanguageId!) {
+    language(id: $language) {
+      # This search:
+      search(params: {
+        query: "foo"
+      }) {
+        ...
+      }
+    }
+
+    # is equivalent to:
+    search(params: {
+      query: "foo"
+      inLanguages: [$language]
+    }) {
+      ...
+    }
+  }
+  ```
+
+  But note that `Language.search` returns a different type that includes only
+  those resources that are searchable in languages.
+  """
+  search(
+    params: SearchInLanguageParams!
+    page: PageParams
+  ): SearchInLanguageResultConnection
 }
 
 "Contains paginated results from the `Language.lemmas` field."
@@ -78,6 +113,84 @@ type LemmaConnection {
 
   "The lemmas in this batch."
   nodes: [Lemma!]!
+}
+
+"Contains paginated results from the `Language.search` field."
+type SearchInLanguageResultConnection {
+  "Pagination metadata for this batch."
+  page: PageInfo!
+
+  "The search results in this batch."
+  nodes: [SearchInLanguageResult!]!
+}
+
+"The result of a search within a language (the `Language.search` field)."
+union SearchInLanguageResult =
+  | LemmaSearchResult
+  | DefinitionSearchResult
+  | PartOfSpeechSearchResult
+
+"""
+Contains search parameters for the `Language.search` field. See that field for
+more documentation and examples.
+"""
+input SearchInLanguageParams {
+  "The free text search query."
+  query: String!
+
+  """
+  The scopes to search within. This specifies the kinds of resources that will
+  be included in the search. Others filters may additionally limit the search
+  scope. For example, a part of speech filter will further constrain the search
+  to resources that have to a part of speech.
+
+  The values `SEARCH_LANGUAGES` and `SEARCH_TAGS` are not valid for language
+  searches. Passing either into this list is an error.
+
+  If omitted or null, all scopes are searched. If empty, no scopes are searched;
+  the result will be empty.
+  """
+  scopes: [SearchScope!]
+
+  """
+  The IDs of parts of speech to search in. This limits the search to resources
+  that have a part of speech (lemmas and definitions). Notably, this *excludes*
+  parts of speech themselves.
+
+  A definition matches if it belongs to *any* of the specified parts of speech.
+  A lemma matches if *any* of its definitions match.
+
+  If omitted or null, no part of speech filter is applied. If empty, no parts
+  of speech are searched; the result will be empty.
+  """
+  inPartsOfSpeech: [PartOfSpeechId!]
+
+  """
+  The IDs of tags to search in. This limits the search to resources that have
+  tags (lemmas and definitions). Notably, this *excludes* tags themselves.
+
+  The value of `tagMatching` determines how these values are used:
+
+  * If `tagMatching` is `MATCH_ANY`, then: a definition matches if it has *any*
+    of the specified tags, and a lemma matches if *any* of its definitions
+    match. In this mode, an empty list means no tags are searched; the result
+    will be empty.
+  * If `tagMatching` is `MATCH_ALL`, then: a definition matches if it has *all*
+    of the specified tags, and a lemma matches if its definitions together have
+    *all* of the speciifed tags. In this mode, an empty list means all lemmas
+    and definitions match (`[]` is a subset of every list).
+
+  If omitted or null, no tag filter is applied.
+  """
+  withTags: [TagId!]
+
+  """
+  Determines how `withTags` matches. See the documentation of `withTags` for
+  more details. If omitted or null, the default value is `MATCH_ANY`.
+
+  This field has no effect if `withTags` is omitted or null.
+  """
+  tagMatching: MatchingMode
 }
 
 extend type Query {

--- a/graphql-schema/search.graphql
+++ b/graphql-schema/search.graphql
@@ -1,0 +1,286 @@
+"The result of a global search (the `search` field on the root query type)."
+union GlobalSearchResult =
+  | LanguageSearchResult
+  | LemmaSearchResult
+  | DefinitionSearchResult
+  | PartOfSpeechSearchResult
+  | TagSearchResult
+
+"A search result that matches a language."
+type LanguageSearchResult {
+  "A snippet over the matching part of the language name."
+  nameSnippet: MatchingSnippet!
+
+  "The language that matched the search."
+  language: Language!
+}
+
+"A search result that matches a lemma."
+type LemmaSearchResult {
+  "A snippet over the matching part of the lemma name."
+  termSnippet: MatchingSnippet!
+
+  "The lemma that matched the search."
+  lemma: Lemma!
+}
+
+"A search result that matches a definition."
+type DefinitionSearchResult {
+  "A snippet over the matching part of the description text."
+  descriptionSnippet: MatchingSnippet!
+
+  "The definition that matched the search."
+  definition: Definition!
+}
+
+"A search result that matches a part of speech."
+type PartOfSpeechSearchResult {
+  "A snippet over the matching part of the part of speech name."
+  nameSnippet: MatchingSnippet!
+
+  "The part of speech that matched the search."
+  partOfSpeech: PartOfSpeech!
+}
+
+"A search result that matches a tag."
+type TagSearchResult {
+  "A snippet over the matching part of the tag name."
+  nameSnippet: MatchingSnippet!
+
+  "The tag that matched the search."
+  tag: Tag!
+}
+
+"""
+This type encapsulates the part of a searchable text field that matched a query,
+along with a small amount of surrounding context. The surrounding content is
+usually a subset of the the searchable field's text, but may be large enough to
+include the full text. This type is used for highlighting where a search query
+matched a field.
+
+Values of this type are not guaranteed to contain every single matching search
+query token.
+"""
+type MatchingSnippet {
+  """
+  If true, the snippet starts before the searched field's text; that is, there
+  exists field text before the first value in `parts`. If false, the `parts`
+  list contains the start of the searched text.
+
+  When this field is true, a highlighted snippet should probably start with a
+  marker to indicate partial content, such as `...`.
+  """
+  partialStart: Boolean!
+
+  """
+  If true, the snippet ends before the searched field's text; that is, there
+  exists field text after the last value in `parts`. If false, the `parts list
+  contains the end of the searched text.
+
+  When this field is true, a highlighted snippet should probably end with a
+  marker to indicate partial content, such as `...`.
+  """
+  partialEnd: Boolean!
+
+  """
+  Text extracted from the searched field. This list contains the parts that
+  matched the search query as well as surrounding context.
+  """
+  parts: [MatchingSnippetPart!]!
+}
+
+"""
+A part of a `MatchingSnippet`, which is either a match for a token from the
+search query, or surrounding text extracted from the searched field. See the
+`MatchingSnippet` type for more details.
+"""
+type MatchingSnippetPart {
+  """
+  True if the part is a search query match; false if it is surrounding context.
+  """
+  isMatch: Boolean!
+
+  "Text from the searched field."
+  text: String!
+}
+
+"Contains paginated results from the `Query.search` field."
+type GlobalSearchResultConnection {
+  "Pagination metadata for this batch."
+  page: PageInfo!
+
+  "The search results in this batch."
+  nodes: [GlobalSearchResult!]!
+}
+
+"""
+Contains search parameters for the `search` field on the root query type. See
+that field for more documentation and examples.
+"""
+input GlobalSearchParams {
+  "The free text search query."
+  query: String!
+
+  """
+  The scopes to search within. This specifies the kinds of resources that will
+  be included in the search. Others filters may additionally limit the search
+  scope. For example, a part of speech filter will further constrain the search
+  to resources that have to a part of speech.
+
+  If omitted or null, all scopes are searched. If empty, no scopes are searched;
+  the result will be empty.
+  """
+  scopes: [SearchScope!]
+
+  """
+  The IDs of languages to search in. This limits the search to resources that
+  belong to a language (parts of speech, lemmas and definitions). Notably, this
+  *excludes* languages themselves.
+
+  A parts of speech, lemma or definition matches if it belongs to *any* of the
+  specified languages.
+
+  If omitted or null, no language filter is applied. If empty, no languages are
+  searched; the result will be empty.
+  """
+  inLanguages: [LanguageId!]
+
+  """
+  The IDs of parts of speech to search in. This limits the search to resources
+  that have a part of speech (lemmas and definitions). Notably, this *excludes*
+  parts of speech themselves.
+
+  A definition matches if it belongs to *any* of the specified parts of speech.
+  A lemma matches if *any* of its definitions match.
+
+  If omitted or null, no part of speech filter is applied. If empty, no parts
+  of speech are searched; the result will be empty.
+  """
+  inPartsOfSpeech: [PartOfSpeechId!]
+
+  """
+  The IDs of tags to search in. This limits the search to resources that have
+  tags (lemmas and definitions). Notably, this *excludes* tags themselves.
+
+  The value of `tagMatching` determines how these values are used:
+
+  * If `tagMatching` is `MATCH_ANY`, then: a definition matches if it has *any*
+    of the specified tags, and a lemma matches if *any* of its definitions
+    match. In this mode, an empty list means no tags are searched; the result
+    will be empty.
+  * If `tagMatching` is `MATCH_ALL`, then: a definition matches if it has *all*
+    of the specified tags, and a lemma matches if its definitions together have
+    *all* of the speciifed tags. In this mode, an empty list means all lemmas
+    and definitions match (`[]` is a subset of every list).
+
+  If omitted or null, no tag filter is applied.
+  """
+  withTags: [TagId!]
+
+  """
+  Determines how `withTags` matches. See the documentation of `withTags` for
+  more details. If omitted or null, the default value is `MATCH_ANY`.
+
+  This field has no effect if `withTags` is omitted or null.
+  """
+  tagMatching: MatchingMode
+}
+
+"""
+The scope of a search; that is, the type of resource that a search applies to.
+Some scopes are invalid in some contexts, and some scopes can be implicitly
+excluded by other search options. For details, see the documentation of each
+input type that uses this enum.
+"""
+enum SearchScope {
+  "Specifies that languages should be searched."
+  SEARCH_LANGUAGES
+
+  "Specifies that lemmas should be searched."
+  SEARCH_LEMMAS
+
+  "Specifies that definitions should be searched."
+  SEARCH_DEFINITIONS
+
+  "Specifies that parts of speech should be searched."
+  SEARCH_PARTS_OF_SPEECH
+
+  "Specifies that tags should be searched."
+  SEARCH_TAGS
+}
+
+"Determines the matching mode of some filterable values."
+enum MatchingMode {
+  """
+  Specifies that the filtered field must match *at least one* of the provided
+  values.
+  """
+  MATCH_ANY
+
+  "Specifies that the filtered field must match *all* of the provided values."
+  MATCH_ALL
+}
+
+extend type Query {
+  """
+  Searches the dictionary.
+
+  The `params` parameter of this field contains a number of fields. The most
+  important is `query`, which contains the free text search query. At minimum,
+  a query to this field must include that:
+
+  ```graphql
+  query {
+    search(params: {
+      # Search for anything matching "foo"
+      query: "foo"
+    }) {
+      ...
+    }
+  }
+  ```
+
+  This field can search through most of the dictionary: lemmas, languages,
+  definitions, and more. The `scope` field specifies the kinds of resources that
+  should be searched:
+
+  ```graphql
+  query($query: String!) {
+    search(params: {
+      query: $query
+      # Search only in languages and lemmas
+      scopes: [SEARCH_LANGUAGES, SEARCH_LEMMAS]
+    }) {
+      ...
+    }
+  }
+  ```
+
+  The search parameters can also include filters for other properties, such as
+  associated tags, part of speech or language. Use of these fields implicitly
+  constrains the type to resources with those fields. For example, only lemmas
+  and definitions have tags, so this example will only return results for those
+  resources (despite broader `scopes`):
+
+  ```graphql
+  query($query: String!, $tag, TagId!) {
+    search(params: {
+      query: $query
+      scopes: [SEARCH_LANGUAGES, SEARCH_LEMMAS, SEARCH_DEFINITIONS, SEARCH_TAGS]
+      # Only definitions and lemmas have tags; languages and tags will not be
+      # present in the result.
+      withTags: [$tag]
+    }) {
+      ...
+    }
+  }
+  ```
+
+  Lastly, searches can match many items, so the results of a search are always
+  paginated. If provided, `page.perPage` cannot exceed 200.
+  """
+  search(
+    params: GlobalSearchParams!
+    page: PageParams
+  ): GlobalSearchResultConnection
+}

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -143,7 +143,7 @@ The returned promise resolves when the server has shut down fully. If any error 
 
 #### `CondictServer.prototype.getContextValue()`
 
-> `getContextValue(sessionId?: string | typeof LocalSession | null): Promise<Context>`
+> `getContextValue(sessionId?: string | typeof LocalSession | null, requestId?: string): Promise<Context>`
 
 Gets a GraphQL execution context value. This value required when executing GraphQL operations. The [`executeLocalOperation()`](#executelocaloperation) function calls this method internally.
 
@@ -152,6 +152,8 @@ The `sessionId` parameter is used for mutation authentication. It takes one of t
 * A session ID string, as returned by the `logIn` mutation. The session ID is valid if it matches an ongoing user session; otherwise, the request is unauthenticated.
 * The symbol `LocalSession`. This indicates that the operation is executed in a trusted context, for example when the server is embedded in an application. All mutations are permitted.
 * `null` or `undefined`, which means the request is unauthenticated. Most mutations are prohibited without authentication.
+
+The `requestId` parameter takes a string that identifies the request. It is prepended to log messages produced by the context's logger.
 
 The returned promise resolves once the context is available. If the server is in the process of shutting down, the promise is rejected.
 

--- a/packages/server/src/create-logger.ts
+++ b/packages/server/src/create-logger.ts
@@ -79,3 +79,27 @@ export const createNullLogger = (): Logger => ({
   verbose() { /* no-op */ },
   debug() { /* no-op */ },
 });
+
+/**
+ * Creates a logger that prepends a prefix to all incoming messages.
+ * @param inner The logger to wrap.
+ * @param prefix The prefix to add to each message.
+ * @return A prefixing logger.
+ */
+export const createPrefixLogger = (inner: Logger, prefix: string): Logger => ({
+  error(msg, ...extra) {
+    inner.error(`${prefix} ${msg}`, ...extra);
+  },
+  warn(msg, ...extra) {
+    inner.warn(`${prefix} ${msg}`, ...extra);
+  },
+  info(msg, ...extra) {
+    inner.info(`${prefix} ${msg}`, ...extra);
+  },
+  verbose(msg, ...extra) {
+    inner.verbose(`${prefix} ${msg}`, ...extra);
+  },
+  debug(msg, ...extra) {
+    inner.debug(`${prefix} ${msg}`, ...extra);
+  },
+});

--- a/packages/server/src/database/sqlite/connection.ts
+++ b/packages/server/src/database/sqlite/connection.ts
@@ -7,7 +7,7 @@ import reindentQuery from '../reindent-query';
 import Accessor from './accessor';
 import RwLock from './rwlock';
 import registerUnicodeCollation from './unicode-collation';
-import {Options, DataAccessor, SqlLogger} from './types';
+import {Options, DataAccessor} from './types';
 
 // NB: "db" refers to instances of better-sqlite3's Database, and "connection"
 // to our own wrapper.
@@ -20,13 +20,13 @@ import {Options, DataAccessor, SqlLogger} from './types';
  * See the documentation of Accessor and RwLock for details.
  */
 export default class Connection {
-  private readonly logger: Logger;
+  private readonly defaultLogger: Logger;
   private readonly db: Database;
   private readonly lock: RwLock;
-  private readonly logSql: SqlLogger;
+  private readonly logSql: (logger: Logger, sql: string) => void;
 
-  public constructor(logger: Logger, options: Options) {
-    this.logger = logger;
+  public constructor(defaultLogger: Logger, options: Options) {
+    this.defaultLogger = defaultLogger;
 
     const db = new Sqlite(options.file);
     db.pragma('journal_mode = WAL');
@@ -36,12 +36,12 @@ export default class Connection {
     this.lock = new RwLock();
 
     if (process.env.DEBUG_QUERIES === '1') {
-      this.logSql = sql => {
+      this.logSql = (logger, sql) => {
         if (/^\s*$/.test(sql)) {
-          this.logger.warn('Empty query?!');
+          logger.warn('Empty query?!');
         } else {
           const reindentedSql = reindentQuery(sql);
-          this.logger.debug(`Query:\n${reindentedSql}`);
+          logger.debug(`Query:\n${reindentedSql}`);
         }
       };
     } else {
@@ -54,13 +54,17 @@ export default class Connection {
    * Gets a connection to the database. The connection has shared read-only
    * access by default, and exclusive read-write access must be requested
    * through the connection object.
+   * @param reqLogger A logger to use for the accessor, if query logging is
+   *        enabled. If omitted or undefined, the connection's default logger
+   *        is used.
    * @return A promise that resolves with the database connection. The promise
    *         is rejected if the connection is closed before the accessor could
    *         be acquired.
    */
-  public async getAccessor(): Promise<DataAccessor> {
+  public async getAccessor(reqLogger?: Logger): Promise<DataAccessor> {
     const token = await this.lock.reader();
-    return new Accessor(this.db, token, this.logSql);
+    const logger = reqLogger ?? this.defaultLogger;
+    return new Accessor(this.db, token, sql => this.logSql(logger, sql));
   }
 
   public async close(): Promise<void> {

--- a/packages/server/src/database/sqlite/types.ts
+++ b/packages/server/src/database/sqlite/types.ts
@@ -293,12 +293,19 @@ export type Awaitable<T> = T | Promise<T>;
  * The `raw` method on the database can be used to construct RawSql values.
  */
 export class RawSql {
-  public sql: string;
-  public params: Param[];
+  public readonly sql: string;
+  public readonly params: readonly Param[];
 
-  public constructor(sql: string, params: Param[]) {
+  public constructor(sql: string, params: readonly Param[]) {
     this.sql = sql;
     this.params = params;
+  }
+
+  public static join(parts: readonly RawSql[], separator: string): RawSql {
+    return new RawSql(
+      parts.map(r => r.sql).join(separator),
+      parts.reduce<readonly Param[]>((acc, r) => acc.concat(r.params), [])
+    );
   }
 }
 

--- a/packages/server/src/graphql/resolvers/index.ts
+++ b/packages/server/src/graphql/resolvers/index.ts
@@ -8,6 +8,7 @@ import LanguageResolvers from './language';
 import LemmaResolvers from './lemma';
 import PartOfSpeechResolvers from './part-of-speech';
 import RootResolvers from './root';
+import SearchResolvers from './search';
 import TagResolvers from './tag';
 import UserResolvers from './user';
 
@@ -27,6 +28,7 @@ export const getResolvers = (): IResolvers<any, any> =>
     LemmaResolvers,
     PartOfSpeechResolvers,
     RootResolvers,
+    SearchResolvers,
     TagResolvers,
     UserResolvers,
   ]) as IResolvers<any, any>;

--- a/packages/server/src/graphql/resolvers/language.ts
+++ b/packages/server/src/graphql/resolvers/language.ts
@@ -5,6 +5,7 @@ import {
   PartOfSpeech,
   Lemma,
   Tag,
+  SearchIndex,
   LanguageRow,
 } from '../../model';
 
@@ -36,6 +37,21 @@ const Language: ResolversFor<LanguageType, LanguageRow> = {
 
   tags: (p, {page}, {db}, info) =>
     Tag.allByLanguage(db, p.id, page, info),
+
+  search: (p, {params, page}, {db}, info) =>
+    SearchIndex.search(
+      db,
+      params.query,
+      params.scopes ?? null,
+      {
+        inLanguages: [p.id],
+        inPartsOfSpeech: params.inPartsOfSpeech ?? null,
+        withTags: params.withTags ?? null,
+        tagMatching: params.tagMatching ?? 'MATCH_ANY',
+      },
+      page,
+      info
+    ),
 };
 
 const Query: ResolversFor<QueryType, null> = {

--- a/packages/server/src/graphql/resolvers/search.ts
+++ b/packages/server/src/graphql/resolvers/search.ts
@@ -1,0 +1,136 @@
+import {
+  SearchIndex,
+  SearchResultRow,
+  LanguageSearchResultRow,
+  LemmaSearchResultRow,
+  DefinitionSearchResultRow,
+  PartOfSpeechSearchResultRow,
+  TagSearchResultRow,
+  MatchingSnippet,
+  Language,
+  Lemma,
+  Definition,
+  PartOfSpeech,
+  Tag,
+} from '../../model';
+
+import {
+  GlobalSearchResult as GlobalSearchResultType,
+  SearchInLanguageResult as SearchInLanguageResultType,
+  LanguageSearchResult as LanguageSearchResultType,
+  LemmaSearchResult as LemmaSearchResultType,
+  DefinitionSearchResult as DefinitionSearchResultType,
+  PartOfSpeechSearchResult as PartOfSpeechSearchResultType,
+  TagSearchResult as TagSearchResultType,
+  Query as QueryType,
+} from '../types';
+
+import {ResolversFor} from './types';
+
+const GlobalSearchResult: ResolversFor<
+  GlobalSearchResultType,
+  SearchResultRow
+> = {
+  __resolveType(p) {
+    switch (p.kind) {
+      case 'language':
+        return 'LanguageSearchResult';
+      case 'lemma':
+        return 'LemmaSearchResult';
+      case 'definition':
+        return 'DefinitionSearchResult';
+      case 'part_of_speech':
+        return 'PartOfSpeechSearchResult';
+      case 'tag':
+        return 'TagSearchResult';
+    }
+  },
+};
+
+const SearchInLanguageResult: ResolversFor<
+  SearchInLanguageResultType,
+  SearchResultRow
+> = {
+  __resolveType(p) {
+    switch (p.kind) {
+      case 'lemma':
+        return 'LemmaSearchResult';
+      case 'definition':
+        return 'DefinitionSearchResult';
+      case 'part_of_speech':
+        return 'PartOfSpeechSearchResult';
+      default:
+        throw new Error(`Unexpected result kind for search-in-language: ${p.kind}`);
+    }
+  },
+};
+
+const LanguageSearchResult: ResolversFor<
+  LanguageSearchResultType,
+  LanguageSearchResultRow
+> = {
+  nameSnippet: p => MatchingSnippet.fromRaw(p.matching_snippet),
+
+  language: (p, _args, {db}) => Language.byId(db, p.id),
+};
+
+const LemmaSearchResult: ResolversFor<
+  LemmaSearchResultType,
+  LemmaSearchResultRow
+> = {
+  termSnippet: p => MatchingSnippet.fromRaw(p.matching_snippet),
+
+  lemma: (p, _args, {db}) => Lemma.byId(db, p.id),
+};
+
+const DefinitionSearchResult: ResolversFor<
+  DefinitionSearchResultType,
+  DefinitionSearchResultRow
+> = {
+  descriptionSnippet: p => MatchingSnippet.fromRaw(p.matching_snippet),
+
+  definition: (p, _args, {db}) => Definition.byId(db, p.id),
+};
+
+const PartOfSpeechSearchResult: ResolversFor<
+  PartOfSpeechSearchResultType,
+  PartOfSpeechSearchResultRow
+> = {
+  nameSnippet: p => MatchingSnippet.fromRaw(p.matching_snippet),
+
+  partOfSpeech: (p, _args, {db}) => PartOfSpeech.byId(db, p.id),
+};
+
+const TagSearchResult: ResolversFor<TagSearchResultType, TagSearchResultRow> = {
+  nameSnippet: p => MatchingSnippet.fromRaw(p.matching_snippet),
+
+  tag: (p, _args, {db}) => Tag.byId(db, p.id),
+};
+
+const Query: ResolversFor<QueryType, null> = {
+  search: (_p, {params, page}, {db}, info) =>
+    SearchIndex.search(
+      db,
+      params.query,
+      params.scopes ?? null,
+      {
+        inLanguages: params.inLanguages ?? null,
+        inPartsOfSpeech: params.inPartsOfSpeech ?? null,
+        withTags: params.withTags ?? null,
+        tagMatching: params.tagMatching ?? 'MATCH_ANY',
+      },
+      page,
+      info
+    ),
+};
+
+export default {
+  GlobalSearchResult,
+  SearchInLanguageResult,
+  LanguageSearchResult,
+  LemmaSearchResult,
+  DefinitionSearchResult,
+  PartOfSpeechSearchResult,
+  TagSearchResult,
+  Query,
+};

--- a/packages/server/src/graphql/resolvers/types.ts
+++ b/packages/server/src/graphql/resolvers/types.ts
@@ -15,6 +15,10 @@ export interface Context {
    */
   readonly sessionId: string | null;
   /**
+   * The request ID of the request, or null if no request ID was provided.
+   */
+  readonly requestId: string | null;
+  /**
    * Determines whether the request has a valid user session.
    * @return True if there is a valid user session, i.e. the requester can
    *         execute mutations.

--- a/packages/server/src/graphql/types.ts
+++ b/packages/server/src/graphql/types.ts
@@ -291,6 +291,20 @@ export type DefinitionLinkTarget = {
 };
 
 /**
+ * A search result that matches a definition.
+ */
+export type DefinitionSearchResult = {
+  /**
+   * A snippet over the matching part of the description text.
+   */
+  descriptionSnippet: MatchingSnippet;
+  /**
+   * The definition that matched the search.
+   */
+  definition: Definition;
+};
+
+/**
  * An inflection stem for a single definition. Stems are used when inflecting the
  * word: inflected forms contain patterns like `{pl}es`, where `{pl}` is replaced
  * with the value of the stem named `pl`.
@@ -557,6 +571,100 @@ export type FormattedTextInput = {
    * `subscript` and `superscript` are mutually exclusive.
    */
   superscript?: boolean | null;
+};
+
+/**
+ * Contains search parameters for the `search` field on the root query type. See
+ * that field for more documentation and examples.
+ */
+export type GlobalSearchParams = {
+  /**
+   * The free text search query.
+   */
+  query: string;
+  /**
+   * The scopes to search within. This specifies the kinds of resources that will
+   * be included in the search. Others filters may additionally limit the search
+   * scope. For example, a part of speech filter will further constrain the search
+   * to resources that have to a part of speech.
+   * 
+   * If omitted or null, all scopes are searched. If empty, no scopes are searched;
+   * the result will be empty.
+   */
+  scopes?: SearchScope[] | null;
+  /**
+   * The IDs of languages to search in. This limits the search to resources that
+   * belong to a language (parts of speech, lemmas and definitions). Notably, this
+   * *excludes* languages themselves.
+   * 
+   * A parts of speech, lemma or definition matches if it belongs to *any* of the
+   * specified languages.
+   * 
+   * If omitted or null, no language filter is applied. If empty, no languages are
+   * searched; the result will be empty.
+   */
+  inLanguages?: LanguageId[] | null;
+  /**
+   * The IDs of parts of speech to search in. This limits the search to resources
+   * that have a part of speech (lemmas and definitions). Notably, this *excludes*
+   * parts of speech themselves.
+   * 
+   * A definition matches if it belongs to *any* of the specified parts of speech.
+   * A lemma matches if *any* of its definitions match.
+   * 
+   * If omitted or null, no part of speech filter is applied. If empty, no parts
+   * of speech are searched; the result will be empty.
+   */
+  inPartsOfSpeech?: PartOfSpeechId[] | null;
+  /**
+   * The IDs of tags to search in. This limits the search to resources that have
+   * tags (lemmas and definitions). Notably, this *excludes* tags themselves.
+   * 
+   * The value of `tagMatching` determines how these values are used:
+   * 
+   * * If `tagMatching` is `MATCH_ANY`, then: a definition matches if it has *any*
+   *   of the specified tags, and a lemma matches if *any* of its definitions
+   *   match. In this mode, an empty list means no tags are searched; the result
+   *   will be empty.
+   * * If `tagMatching` is `MATCH_ALL`, then: a definition matches if it has *all*
+   *   of the specified tags, and a lemma matches if its definitions together have
+   *   *all* of the speciifed tags. In this mode, an empty list means all lemmas
+   *   and definitions match (`[]` is a subset of every list).
+   * 
+   * If omitted or null, no tag filter is applied.
+   */
+  withTags?: TagId[] | null;
+  /**
+   * Determines how `withTags` matches. See the documentation of `withTags` for
+   * more details. If omitted or null, the default value is `MATCH_ANY`.
+   * 
+   * This field has no effect if `withTags` is omitted or null.
+   */
+  tagMatching?: MatchingMode | null;
+};
+
+/**
+ * The result of a global search (the `search` field on the root query type).
+ */
+export type GlobalSearchResult =
+  | LanguageSearchResult
+  | LemmaSearchResult
+  | DefinitionSearchResult
+  | PartOfSpeechSearchResult
+  | TagSearchResult;
+
+/**
+ * Contains paginated results from the `Query.search` field.
+ */
+export type GlobalSearchResultConnection = {
+  /**
+   * Pagination metadata for this batch.
+   */
+  page: PageInfo;
+  /**
+   * The search results in this batch.
+   */
+  nodes: GlobalSearchResult[];
 };
 
 /**
@@ -991,6 +1099,40 @@ export type Language = {
   tags: WithArgs<{
     page?: PageParams | null;
   }, TagConnection>;
+  /**
+   * Searches the language. This field behaves like `Query.search` with an implicit
+   * language filter. See that field for more documentation and examples.
+   * 
+   * The following are equivalent:
+   * 
+   * ```graphql
+   * query($language: LanguageId!) {
+   *   language(id: $language) {
+   *     # This search:
+   *     search(params: {
+   *       query: "foo"
+   *     }) {
+   *       ...
+   *     }
+   *   }
+   * 
+   *   # is equivalent to:
+   *   search(params: {
+   *     query: "foo"
+   *     inLanguages: [$language]
+   *   }) {
+   *     ...
+   *   }
+   * }
+   * ```
+   * 
+   * But note that `Language.search` returns a different type that includes only
+   * those resources that are searchable in languages.
+   */
+  search: WithArgs<{
+    params: SearchInLanguageParams;
+    page?: PageParams | null;
+  }, SearchInLanguageResultConnection | null>;
 };
 
 /**
@@ -1011,6 +1153,20 @@ export type LanguageLinkTarget = {
    * the link was created, this field is null.
    */
   language: Language | null;
+};
+
+/**
+ * A search result that matches a language.
+ */
+export type LanguageSearchResult = {
+  /**
+   * A snippet over the matching part of the language name.
+   */
+  nameSnippet: MatchingSnippet;
+  /**
+   * The language that matched the search.
+   */
+  language: Language;
 };
 
 /**
@@ -1107,6 +1263,20 @@ export type LemmaLinkTarget = {
 };
 
 /**
+ * A search result that matches a lemma.
+ */
+export type LemmaSearchResult = {
+  /**
+   * A snippet over the matching part of the lemma name.
+   */
+  termSnippet: MatchingSnippet;
+  /**
+   * The lemma that matched the search.
+   */
+  lemma: Lemma;
+};
+
+/**
  * An inline element that represents a link, either to an item in the dictionary,
  * or to an arbitrary external URI. Link elements may not contain other links.
  */
@@ -1196,6 +1366,73 @@ export type MarshalType =
    */
   | 'STRING_TYPE'
 ;
+
+/**
+ * Determines the matching mode of some filterable values.
+ */
+export type MatchingMode =
+  /**
+   * Specifies that the filtered field must match *at least one* of the provided
+   * values.
+   */
+  | 'MATCH_ANY'
+  /**
+   * Specifies that the filtered field must match *all* of the provided values.
+   */
+  | 'MATCH_ALL'
+;
+
+/**
+ * This type encapsulates the part of a searchable text field that matched a query,
+ * along with a small amount of surrounding context. The surrounding content is
+ * usually a subset of the the searchable field's text, but may be large enough to
+ * include the full text. This type is used for highlighting where a search query
+ * matched a field.
+ * 
+ * Values of this type are not guaranteed to contain every single matching search
+ * query token.
+ */
+export type MatchingSnippet = {
+  /**
+   * If true, the snippet starts before the searched field's text; that is, there
+   * exists field text before the first value in `parts`. If false, the `parts`
+   * list contains the start of the searched text.
+   * 
+   * When this field is true, a highlighted snippet should probably start with a
+   * marker to indicate partial content, such as `...`.
+   */
+  partialStart: boolean;
+  /**
+   * If true, the snippet ends before the searched field's text; that is, there
+   * exists field text after the last value in `parts`. If false, the `parts list
+   * contains the end of the searched text.
+   * 
+   * When this field is true, a highlighted snippet should probably end with a
+   * marker to indicate partial content, such as `...`.
+   */
+  partialEnd: boolean;
+  /**
+   * Text extracted from the searched field. This list contains the parts that
+   * matched the search query as well as surrounding context.
+   */
+  parts: MatchingSnippetPart[];
+};
+
+/**
+ * A part of a `MatchingSnippet`, which is either a match for a token from the
+ * search query, or surrounding text extracted from the searched field. See the
+ * `MatchingSnippet` type for more details.
+ */
+export type MatchingSnippetPart = {
+  /**
+   * True if the part is a search query match; false if it is surrounding context.
+   */
+  isMatch: boolean;
+  /**
+   * Text from the searched field.
+   */
+  text: string;
+};
 
 /**
  * The root mutation type.
@@ -1530,6 +1767,20 @@ export type PartOfSpeechLinkTarget = {
 };
 
 /**
+ * A search result that matches a part of speech.
+ */
+export type PartOfSpeechSearchResult = {
+  /**
+   * A snippet over the matching part of the part of speech name.
+   */
+  nameSnippet: MatchingSnippet;
+  /**
+   * The part of speech that matched the search.
+   */
+  partOfSpeech: PartOfSpeech;
+};
+
+/**
  * The root query type.
  */
 export type Query = {
@@ -1586,6 +1837,67 @@ export type Query = {
     id: PartOfSpeechId;
   }, PartOfSpeech | null>;
   /**
+   * Searches the dictionary.
+   * 
+   * The `params` parameter of this field contains a number of fields. The most
+   * important is `query`, which contains the free text search query. At minimum,
+   * a query to this field must include that:
+   * 
+   * ```graphql
+   * query {
+   *   search(params: {
+   *     # Search for anything matching "foo"
+   *     query: "foo"
+   *   }) {
+   *     ...
+   *   }
+   * }
+   * ```
+   * 
+   * This field can search through most of the dictionary: lemmas, languages,
+   * definitions, and more. The `scope` field specifies the kinds of resources that
+   * should be searched:
+   * 
+   * ```graphql
+   * query($query: String!) {
+   *   search(params: {
+   *     query: $query
+   *     # Search only in languages and lemmas
+   *     scopes: [SEARCH_LANGUAGES, SEARCH_LEMMAS]
+   *   }) {
+   *     ...
+   *   }
+   * }
+   * ```
+   * 
+   * The search parameters can also include filters for other properties, such as
+   * associated tags, part of speech or language. Use of these fields implicitly
+   * constrains the type to resources with those fields. For example, only lemmas
+   * and definitions have tags, so this example will only return results for those
+   * resources (despite broader `scopes`):
+   * 
+   * ```graphql
+   * query($query: String!, $tag, TagId!) {
+   *   search(params: {
+   *     query: $query
+   *     scopes: [SEARCH_LANGUAGES, SEARCH_LEMMAS, SEARCH_DEFINITIONS, SEARCH_TAGS]
+   *     # Only definitions and lemmas have tags; languages and tags will not be
+   *     # present in the result.
+   *     withTags: [$tag]
+   *   }) {
+   *     ...
+   *   }
+   * }
+   * ```
+   * 
+   * Lastly, searches can match many items, so the results of a search are always
+   * paginated. If provided, `page.perPage` cannot exceed 200.
+   */
+  search: WithArgs<{
+    params: GlobalSearchParams;
+    page?: PageParams | null;
+  }, GlobalSearchResultConnection | null>;
+  /**
    * The tags that exist in the dictionary. Since a dictionary may contain many
    * tags, this field is always paginated. If provided, `page.perPage` cannot
    * exceed 200.
@@ -1602,6 +1914,118 @@ export type Query = {
     name?: string | null;
   }, Tag | null>;
 };
+
+/**
+ * Contains search parameters for the `Language.search` field. See that field for
+ * more documentation and examples.
+ */
+export type SearchInLanguageParams = {
+  /**
+   * The free text search query.
+   */
+  query: string;
+  /**
+   * The scopes to search within. This specifies the kinds of resources that will
+   * be included in the search. Others filters may additionally limit the search
+   * scope. For example, a part of speech filter will further constrain the search
+   * to resources that have to a part of speech.
+   * 
+   * The values `SEARCH_LANGUAGES` and `SEARCH_TAGS` are not valid for language
+   * searches. Passing either into this list is an error.
+   * 
+   * If omitted or null, all scopes are searched. If empty, no scopes are searched;
+   * the result will be empty.
+   */
+  scopes?: SearchScope[] | null;
+  /**
+   * The IDs of parts of speech to search in. This limits the search to resources
+   * that have a part of speech (lemmas and definitions). Notably, this *excludes*
+   * parts of speech themselves.
+   * 
+   * A definition matches if it belongs to *any* of the specified parts of speech.
+   * A lemma matches if *any* of its definitions match.
+   * 
+   * If omitted or null, no part of speech filter is applied. If empty, no parts
+   * of speech are searched; the result will be empty.
+   */
+  inPartsOfSpeech?: PartOfSpeechId[] | null;
+  /**
+   * The IDs of tags to search in. This limits the search to resources that have
+   * tags (lemmas and definitions). Notably, this *excludes* tags themselves.
+   * 
+   * The value of `tagMatching` determines how these values are used:
+   * 
+   * * If `tagMatching` is `MATCH_ANY`, then: a definition matches if it has *any*
+   *   of the specified tags, and a lemma matches if *any* of its definitions
+   *   match. In this mode, an empty list means no tags are searched; the result
+   *   will be empty.
+   * * If `tagMatching` is `MATCH_ALL`, then: a definition matches if it has *all*
+   *   of the specified tags, and a lemma matches if its definitions together have
+   *   *all* of the speciifed tags. In this mode, an empty list means all lemmas
+   *   and definitions match (`[]` is a subset of every list).
+   * 
+   * If omitted or null, no tag filter is applied.
+   */
+  withTags?: TagId[] | null;
+  /**
+   * Determines how `withTags` matches. See the documentation of `withTags` for
+   * more details. If omitted or null, the default value is `MATCH_ANY`.
+   * 
+   * This field has no effect if `withTags` is omitted or null.
+   */
+  tagMatching?: MatchingMode | null;
+};
+
+/**
+ * The result of a search within a language (the `Language.search` field).
+ */
+export type SearchInLanguageResult =
+  | LemmaSearchResult
+  | DefinitionSearchResult
+  | PartOfSpeechSearchResult;
+
+/**
+ * Contains paginated results from the `Language.search` field.
+ */
+export type SearchInLanguageResultConnection = {
+  /**
+   * Pagination metadata for this batch.
+   */
+  page: PageInfo;
+  /**
+   * The search results in this batch.
+   */
+  nodes: SearchInLanguageResult[];
+};
+
+/**
+ * The scope of a search; that is, the type of resource that a search applies to.
+ * Some scopes are invalid in some contexts, and some scopes can be implicitly
+ * excluded by other search options. For details, see the documentation of each
+ * input type that uses this enum.
+ */
+export type SearchScope =
+  /**
+   * Specifies that languages should be searched.
+   */
+  | 'SEARCH_LANGUAGES'
+  /**
+   * Specifies that lemmas should be searched.
+   */
+  | 'SEARCH_LEMMAS'
+  /**
+   * Specifies that definitions should be searched.
+   */
+  | 'SEARCH_DEFINITIONS'
+  /**
+   * Specifies that parts of speech should be searched.
+   */
+  | 'SEARCH_PARTS_OF_SPEECH'
+  /**
+   * Specifies that tags should be searched.
+   */
+  | 'SEARCH_TAGS'
+;
 
 /**
  * Input type for a definition inflection stem.
@@ -1674,6 +2098,20 @@ export type TagConnection = {
  * Represents a tag ID.
  */
 export type TagId = IdOf<'Tag'>;
+
+/**
+ * A search result that matches a tag.
+ */
+export type TagSearchResult = {
+  /**
+   * A snippet over the matching part of the tag name.
+   */
+  nameSnippet: MatchingSnippet;
+  /**
+   * The tag that matched the search.
+   */
+  tag: Tag;
+};
 
 /**
  * Represents a user session. User sessions can be obtained by using the `logIn` or

--- a/packages/server/src/http-server.ts
+++ b/packages/server/src/http-server.ts
@@ -36,21 +36,21 @@ export default class CondictHttpServer {
       schema: server.getSchema(),
       rootValue: null,
       context: ({req}) => this.server.getContextValue(
-        req.header('x-condict-session-id')
+        req.header('x-condict-session-id'),
+        genRequestId()
       ),
       plugins: [{
         requestDidStart: (req: GraphQLRequestContext<Context>) => {
-          const {logger} = this;
+          const {context} = req;
 
-          const requestId = genRequestId();
           const startTime = Date.now();
-          this.logger.verbose(`Start request ${requestId}`);
+          context.logger.verbose(`Start request`);
 
           return {
             willSendResponse() {
-              req.context.finish();
               const requestTime = Date.now() - startTime;
-              logger.verbose(`Request ${requestId} finished in ${requestTime} ms`);
+              context.logger.verbose(`Request finished in ${requestTime} ms`);
+              req.context.finish();
             },
           };
         },

--- a/packages/server/src/model/description/mut.ts
+++ b/packages/server/src/model/description/mut.ts
@@ -3,7 +3,7 @@ import {LinkRefCollector, validateDescription} from '../../rich-text';
 import {BlockElementInput} from '../../graphql';
 
 import {Description} from './model';
-import {DescriptionId} from './types';
+import {DescriptionId, DescriptionData} from './types';
 
 const ignoreLinkRefs: LinkRefCollector = () => { /* no-op */ };
 
@@ -11,31 +11,31 @@ const DescriptionMut = {
   insert(
     db: DataWriter,
     description: BlockElementInput[]
-  ): DescriptionId {
+  ): DescriptionData {
     const finalDescription = validateDescription(description, ignoreLinkRefs);
 
     const {insertId: id} = db.exec<DescriptionId>`
       insert into descriptions (description)
       values (${JSON.stringify(finalDescription)})
     `;
-    return id;
+    return {id, description: finalDescription};
   },
 
   update(
     db: DataWriter,
     id: DescriptionId,
     description: BlockElementInput[]
-  ): boolean {
+  ): DescriptionData {
     const finalDescription = validateDescription(description, ignoreLinkRefs);
 
-    const {affectedRows} = db.exec`
+    db.exec`
       update descriptions
       set description = ${JSON.stringify(finalDescription)}
       where id = ${id}
     `;
     db.clearCache(Description.rawByIdKey, id);
 
-    return affectedRows > 0;
+    return {id, description: finalDescription};
   },
 
   delete(db: DataWriter, id: DescriptionId): boolean {

--- a/packages/server/src/model/description/types.ts
+++ b/packages/server/src/model/description/types.ts
@@ -1,3 +1,4 @@
+import {BlockElementJson} from '../../rich-text';
 import {IdOf} from '../../graphql/types';
 
 export type DescriptionId = IdOf<'Descripton'>;
@@ -6,4 +7,9 @@ export type DescriptionRow = {
   id: DescriptionId;
   /** JSON-serialized data */
   description: string;
+};
+
+export type DescriptionData = {
+  id: DescriptionId;
+  description: BlockElementJson[];
 };

--- a/packages/server/src/model/index.ts
+++ b/packages/server/src/model/index.ts
@@ -4,6 +4,7 @@ export * from './inflection-table';
 export * from './language';
 export * from './lemma';
 export * from './part-of-speech';
+export * from './search-index';
 export * from './tag';
 export * from './user';
 

--- a/packages/server/src/model/lemma/mut.ts
+++ b/packages/server/src/model/lemma/mut.ts
@@ -1,6 +1,8 @@
 import {LemmaId, LanguageId} from '../../graphql';
 import {DataWriter} from '../../database';
 
+import {SearchIndexMut} from '../search-index';
+
 import {Lemma} from './model';
 import {ValidTerm} from './validators';
 
@@ -24,6 +26,7 @@ const LemmaMut = {
       insert into lemmas (language_id, term)
       values (${languageId}, ${term})
     `;
+    SearchIndexMut.insertLemma(db, insertId, term);
     this.updateLemmaCount(db, languageId);
     return insertId;
   },
@@ -33,8 +36,6 @@ const LemmaMut = {
     languageId: LanguageId,
     terms: ValidTerm[]
   ): Map<string, LemmaId> {
-    // FIXME: https://github.com/typescript-eslint/typescript-eslint/issues/2452
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     type Row = {
       id: LemmaId;
       term: string;
@@ -57,45 +58,52 @@ const LemmaMut = {
       result.map<[string, LemmaId]>(row => [row.term, row.id])
     );
 
-    let hasNewTerms = false;
-    for (const term of terms) {
-      // TODO: Can we parallelise this? Auto-increment IDs *should* be serial.
-      if (!termToId.has(term)) {
-        const {insertId} = db.exec<LemmaId>`
-          insert into lemmas (language_id, term)
-          values (${languageId}, ${term})
-        `;
-        termToId.set(term, insertId);
-        hasNewTerms = true;
-      }
-    }
+    const newTerms = terms.filter(t => !termToId.has(t));
+    if (newTerms.length > 0) {
+      const newLemmas = db.all<Row>`
+        insert into lemmas (language_id, term)
+        values ${newTerms.map(t => db.raw`(${languageId}, ${t})`)}
+        returning id, term
+      `;
 
-    if (hasNewTerms) {
+      SearchIndexMut.insertLemmas(db, newLemmas);
+
       // At least one term was inserted, so we need to update the count.
       this.updateLemmaCount(db, languageId);
+
+      for (const lemma of newLemmas) {
+        termToId.set(lemma.term, lemma.id);
+      }
     }
 
     return termToId;
   },
 
   deleteEmpty(db: DataWriter, languageId: LanguageId): void {
-    const emptyIds = db.all<{id: LemmaId}>`
-      select l.id as id
-      from lemmas l
-      left join definitions d on d.lemma_id = l.id
-      left join derived_definitions dd on dd.lemma_id = l.id
-      where l.language_id = ${languageId}
-        and d.id is null
-        and dd.original_definition_id is null
+    const deleted = db.all<{id: LemmaId}>`
+      with empty_lemmas(id) as (
+        select l.id as id
+        from lemmas l
+        left join definitions d on d.lemma_id = l.id
+        left join derived_definitions dd on dd.lemma_id = l.id
+        where l.languages_id = ${languageId}
+          and d.id is null
+          and dd.original_definition_id is null
+      )
+      delete from lemmas
+      where id in (select id from empty_lemmas)
+      returning id
     `;
 
-    if (emptyIds.length > 0) {
-      emptyIds.forEach(row => db.clearCache(Lemma.byIdKey, row.id));
+    if (deleted.length > 0) {
+      const ids = deleted.map(d => d.id);
 
-      db.exec`
-        delete from lemmas
-        where id in (${emptyIds.map(row => row.id)})
-      `;
+      for (const id of ids) {
+        db.clearCache(Lemma.byIdKey, id);
+      }
+
+      SearchIndexMut.deleteLemmas(db, ids);
+
       this.updateLemmaCount(db, languageId);
     }
   },

--- a/packages/server/src/model/part-of-speech/mut.ts
+++ b/packages/server/src/model/part-of-speech/mut.ts
@@ -9,6 +9,7 @@ import {
 
 import {Language} from '../language';
 import {Definition} from '../definition';
+import {SearchIndexMut} from '../search-index';
 
 import {PartOfSpeech} from './model';
 import {PartOfSpeechRow} from './types';
@@ -31,6 +32,9 @@ const PartOfSpeechMut = {
         insert into parts_of_speech (language_id, name)
         values (${language.id}, ${name})
       `;
+
+      SearchIndexMut.insertPartOfSpeech(db, insertId, name);
+
       return PartOfSpeech.byIdRequired(db, insertId);
     });
   },
@@ -58,6 +62,9 @@ const PartOfSpeechMut = {
           set name = ${newName}
           where id = ${partOfSpeech.id}
         `;
+
+        SearchIndexMut.updatePartOfSpeech(db, partOfSpeech.id, newName);
+
         db.clearCache(PartOfSpeech.byIdKey, partOfSpeech.id);
       });
     }
@@ -73,6 +80,9 @@ const PartOfSpeechMut = {
         delete from parts_of_speech
         where id = ${id}
       `;
+
+      SearchIndexMut.deletePartOfSpeech(db, id);
+
       return affectedRows > 0;
     });
   },

--- a/packages/server/src/model/search-index/index.ts
+++ b/packages/server/src/model/search-index/index.ts
@@ -1,0 +1,3 @@
+export {SearchIndex, MatchingSnippet} from './model';
+export {SearchIndexMut} from './mut';
+export * from './types';

--- a/packages/server/src/model/search-index/model.ts
+++ b/packages/server/src/model/search-index/model.ts
@@ -1,0 +1,145 @@
+import {GraphQLResolveInfo} from 'graphql';
+
+import {DataReader, RawSql} from '../../database';
+import {
+  SearchScope,
+  MatchingSnippet,
+  MatchingSnippetPart,
+  PageParams,
+  validatePageParams,
+} from '../../graphql';
+
+import paginate from '../paginate';
+import {ItemConnection} from '../types';
+
+import {ScopeSql, AllScopes, findValidScopes, buildSearchSql} from './scopes';
+import {MatchStart, MatchEnd, Partial} from './snippet';
+import formatFtsQuery from './query';
+import {SearchResultRow, SearchFilters} from './types';
+
+const formatCountQuery = (part: ScopeSql): RawSql =>
+  new RawSql(
+    `select count(*) as total ${part.fromJoinWhere.sql}`,
+    part.fromJoinWhere.params
+  );
+
+const formatDataQuery = (part: ScopeSql): RawSql =>
+  new RawSql(
+    `select ${part.fields.sql} ${part.fromJoinWhere.sql}`,
+    [...part.fields.params, ...part.fromJoinWhere.params]
+  );
+
+const SearchIndex = {
+  defaultPagination: {
+    page: 0,
+    perPage: 50,
+  },
+  maxPerPage: 200,
+
+  search(
+    db: DataReader,
+    query: string,
+    scopes: readonly SearchScope[] | null,
+    filters: SearchFilters,
+    page: PageParams | undefined | null,
+    info?: GraphQLResolveInfo
+  ): ItemConnection<SearchResultRow> {
+    page = validatePageParams(page || this.defaultPagination, this.maxPerPage);
+
+    // First step: figure out which scopes we can search given the input scopes
+    // and current filters.
+    const validScopes = findValidScopes(scopes ?? AllScopes, filters);
+    const ftsQuery = formatFtsQuery(query);
+
+    if (
+      // Empty query = empty result.
+      !ftsQuery ||
+      // No scopes = nothing to search.
+      validScopes.size === 0 ||
+      // Languages specified but empty = no language to search.
+      filters.inLanguages && filters.inLanguages.length === 0 ||
+      // Parts of speech specified but empty = no language to search.
+      filters.inPartsOfSpeech && filters.inPartsOfSpeech.length === 0 ||
+      // Tags specified but empty *and* tagMatching is MATCH_ANY = no tags to
+      // filter by.
+      // NB: MATCH_ALL always succeeds against `[]` because `[]` is a subset
+      // of every list.
+      filters.withTags &&
+        filters.withTags.length === 0 &&
+        filters.tagMatching === 'MATCH_ANY'
+    ) {
+      return {
+        page: {
+          page: page.page,
+          perPage: page.perPage,
+          totalCount: 0,
+        },
+        nodes: [],
+      };
+    }
+
+    const sqlParts = buildSearchSql(db, ftsQuery, validScopes, filters);
+
+    return paginate(
+      page,
+      () => {
+        const {total} = db.getRequired<{total: number}>`
+          select sum(total) as total
+          from (${RawSql.join(sqlParts.map(formatCountQuery), ' union all ')}) t
+        `;
+        return total;
+      },
+      (limit, offset) => db.all<SearchResultRow>`
+        ${RawSql.join(sqlParts.map(formatDataQuery), ' union all ')}
+        order by score
+        limit ${limit} offset ${offset}
+      `,
+      info
+    );
+  },
+} as const;
+
+const MatchingSnippet = {
+  fromRaw(text: string): MatchingSnippet {
+    const partialStart = text.startsWith(Partial);
+    const partialEnd = text.endsWith(Partial);
+
+    // If partialStart, the first part starts past the Partial marker.
+    let index = partialStart ? Partial.length : 0;
+    // If partialEnd, the last part ends before the Partial marker.
+    const end = text.length - (partialEnd ? Partial.length : 0);
+
+    const parts: MatchingSnippetPart[] = [];
+
+    while (index < end) {
+      const matchStart = text.indexOf(MatchStart, index);
+      if (matchStart !== -1) {
+        if (index < matchStart) {
+          parts.push({
+            isMatch: false,
+            text: text.slice(index, matchStart),
+          });
+        }
+
+        const matchEnd = text.indexOf(MatchEnd, matchStart + MatchStart.length);
+        parts.push({
+          isMatch: true,
+          text: text.slice(matchStart + MatchStart.length, matchEnd),
+        });
+
+        index = matchEnd + MatchEnd.length;
+      } else {
+        parts.push({
+          isMatch: false,
+          text: text.slice(index, end),
+        });
+        // No more matches are possible.
+        break;
+      }
+    }
+
+    return {partialStart, partialEnd, parts};
+  },
+} as const;
+
+export {SearchIndex, MatchingSnippet};

--- a/packages/server/src/model/search-index/mut.ts
+++ b/packages/server/src/model/search-index/mut.ts
@@ -1,0 +1,146 @@
+import {DataWriter} from '../../database';
+import {
+  LanguageId,
+  LemmaId,
+  DefinitionId,
+  PartOfSpeechId,
+  TagId,
+} from '../../graphql';
+import {BlockElementJson, InlineElementJson} from '../../rich-text';
+
+import {LemmaSearchIndexInput, TagSearchIndexInput} from './types';
+
+const SearchIndexMut = {
+  insertLanguage(db: DataWriter, id: LanguageId, name: string): void {
+    db.exec`
+      insert into languages_fts (rowid, name)
+      values (${id}, ${name})
+    `;
+  },
+
+  updateLanguage(db: DataWriter, id: LanguageId, name: string): void {
+    db.exec`
+      update languages_fts
+      set name = ${name}
+      where rowid = ${id}
+    `;
+  },
+
+  deleteLanguage(db: DataWriter, id: LanguageId): void {
+    db.exec`
+      delete from languages_fts
+      where rowid = ${id}
+    `;
+  },
+
+  insertLemma(db: DataWriter, id: LemmaId, term: string): void {
+    db.exec`
+      insert into lemmas_fts (rowid, term)
+      values (${id}, ${term})
+    `;
+  },
+
+  insertLemmas(db: DataWriter, lemmas: LemmaSearchIndexInput[]): void {
+    db.exec`
+      insert into lemmas_fts (rowid, term)
+      values ${lemmas.map(lm => db.raw`(${lm.id}, ${lm.term})`)}
+    `;
+  },
+
+  deleteLemmas(db: DataWriter, ids: readonly LemmaId[]): void {
+    db.exec`
+      delete from lemmas_fts
+      where rowid in (${ids})
+    `;
+  },
+
+  insertDefinition(
+    db: DataWriter,
+    id: DefinitionId,
+    description: readonly BlockElementJson[]
+  ): void {
+    const plainTextDescription = richTextToPlainText(description);
+    db.exec`
+      insert into definitions_fts (rowid, description)
+      values (${id}, ${plainTextDescription})
+    `;
+  },
+
+  updateDefinition(
+    db: DataWriter,
+    id: DefinitionId,
+    description: readonly BlockElementJson[]
+  ): void {
+    const plainTextDescription = richTextToPlainText(description);
+    db.exec`
+      update definitions_fts
+      set description = ${plainTextDescription}
+      where rowid = ${id}
+    `;
+  },
+
+  deleteDefinition(db: DataWriter, id: DefinitionId): void {
+    db.exec`
+      delete from definitions_fts
+      where rowid = ${id}
+    `;
+  },
+
+  insertPartOfSpeech(db: DataWriter, id: PartOfSpeechId, name: string): void {
+    db.exec`
+      insert into parts_of_speech_fts (rowid, name)
+      values (${id}, ${name})
+    `;
+  },
+
+  updatePartOfSpeech(db: DataWriter, id: PartOfSpeechId, name: string): void {
+    db.exec`
+      update parts_of_speech_fts
+      set name = ${name}
+      where rowid = ${id}
+    `;
+  },
+
+  deletePartOfSpeech(db: DataWriter, id: PartOfSpeechId): void {
+    db.exec`
+      delete from parts_of_speech_fts
+      where rowid = ${id}
+    `;
+  },
+
+  insertTags(db: DataWriter, tags: TagSearchIndexInput[]): void {
+    db.exec`
+      insert into tags_fts (rowid, name)
+      values ${tags.map(t => db.raw`(${t.id}, ${t.name})`)}
+    `;
+  },
+
+  deleteTags(db: DataWriter, ids: readonly TagId[]): void {
+    db.exec`
+      delete from tags_fts
+      where rowid in (${ids})
+    `;
+  },
+} as const;
+
+const richTextToPlainText = (richText: readonly BlockElementJson[]): string => {
+  const lines: string[] = [];
+
+  for (const block of richText) {
+    let texts: string[] = [];
+
+    for (const inline of block.inlines) {
+      if (InlineElementJson.isLink(inline)) {
+        texts = texts.concat(inline.inlines.map(t => t.text));
+      } else {
+        texts.push(inline.text);
+      }
+    }
+
+    lines.push(texts.join(''));
+  }
+
+  return lines.join('\n');
+};
+
+export {SearchIndexMut};

--- a/packages/server/src/model/search-index/query.ts
+++ b/packages/server/src/model/search-index/query.ts
@@ -1,0 +1,53 @@
+// NOTE: The characters included here MUST match the FTS tokenize options
+// from the database schema (../../database/schema).
+const TokenPattern = /[\p{L}\p{N}\p{Co}\p{Mc}\p{Mn}']+/u;
+
+const quotePrefixToken = (token: string): string => `"${token}"*`;
+
+const formatFtsQuery = (query: string): string => {
+  // Quotes surround literal patterns and phrases; these must match exactly.
+  // In the generated FTS query, the tokens within are preserved as written.
+  // Non-quoted tokens are quoted for the query and have `*` appended to them,
+  // turning them into token prefix matches.
+  // For example, the input `"foo, bar" baz` will turn into the FTS query
+  // `"foo bar" "baz"*`
+  // A quoted phrase is allowed to have a missing end quote, in whith case it
+  // extends to the end of the string. This allows quoted phrases to be used
+  // as such while the user is still typing them.
+  //
+  // Capturing groups:
+  //   1: content of quoted phrase
+  //   2: non-quoted token(s)
+  const groupPattern = /"([^"]*)(?:"|$)|([^"\s]+)/g;
+
+  const phrases: string[] = [];
+
+  let m: RegExpExecArray | null;
+  while ((m = groupPattern.exec(query)) !== null) {
+    if (m[1]) {
+      // Quoted group
+      // We perform our own tokenization of the phrase, so we can check that
+      // it is not empty.
+
+      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+      const tokens = m[1].match(TokenPattern);
+      if (tokens) {
+        phrases.push(`"${tokens.join(' ')}"`);
+      }
+    } else {
+      // Non-quoted token(s).
+      // Note: we may match multiple tokens here, if the captured text is
+      // something like `foo,bar+baz`.
+
+      // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+      const tokens = m[2].match(TokenPattern);
+      if (tokens) {
+        phrases.push(...tokens.map(quotePrefixToken));
+      }
+    }
+  }
+
+  return phrases.join(' ');
+};
+
+export default formatFtsQuery;

--- a/packages/server/src/model/search-index/scopes.ts
+++ b/packages/server/src/model/search-index/scopes.ts
@@ -1,0 +1,226 @@
+import {SearchScope} from '../../graphql';
+
+import {DataReader, RawSql} from '../../database';
+
+import {Partial, MatchStart, MatchEnd} from './snippet';
+import {SearchFilters} from './types';
+
+export interface ScopeSql {
+  /**
+   * Field selections for this scope. Includes everything between `select` and
+   * `from`.
+   */
+  readonly fields: RawSql;
+  /**
+   * The `from` part, `join`s, and `where` clause as necessary, including the
+   * leading `from`.
+   */
+  readonly fromJoinWhere: RawSql;
+}
+
+interface ScopeInfo {
+  readonly acceptsLanguageFilter?: boolean;
+  readonly acceptsPartOfSpeechFilter?: boolean;
+  readonly acceptsTagFilter?: boolean;
+  readonly buildSql: ScopeQueryGenerator;
+}
+
+type ScopeQueryGenerator = (
+  db: DataReader,
+  ftsQuery: string,
+  filters: SearchFilters
+) => ScopeSql;
+
+export const AllScopes: readonly SearchScope[] = [
+  'SEARCH_LANGUAGES',
+  'SEARCH_LEMMAS',
+  'SEARCH_DEFINITIONS',
+  'SEARCH_PARTS_OF_SPEECH',
+  'SEARCH_TAGS',
+];
+
+/**
+ * Shared arguments to the snippet() function.
+ * text before match, text after match, start/end partial, max tokens
+ */
+const SnippetArgs = new RawSql(
+  `'${MatchStart}', '${MatchEnd}', '${Partial}', 32`,
+  []
+);
+
+const EmptySql = new RawSql('', []);
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+const AllScopeInfo: Record<SearchScope, ScopeInfo> = {
+  SEARCH_LANGUAGES: {
+    buildSql(db, ftsQuery) {
+      return {
+        fields: db.raw`
+          'language' as kind,
+          lng.id as id,
+          snippet(languages_fts, 0, ${SnippetArgs}) as matching_snippet,
+          languages_fts.rank as score
+        `,
+        fromJoinWhere: db.raw`
+          from languages_fts
+          inner join languages lng on lng.id = languages_fts.rowid
+          where languages_fts match ${ftsQuery}
+        `,
+      };
+    },
+  },
+  SEARCH_LEMMAS: {
+    acceptsLanguageFilter: true,
+    acceptsPartOfSpeechFilter: true,
+    acceptsTagFilter: true,
+    buildSql(db, ftsQuery, filters) {
+      const needTagFilter = filters.withTags && filters.withTags.length > 0;
+      return {
+        fields: db.raw`
+          'lemma' as kind,
+          lm.id as id,
+          snippet(lemmas_fts, 0, ${SnippetArgs}) as matching_snippet,
+          lemmas_fts.rank as score
+        `,
+        fromJoinWhere: db.raw`
+          from lemmas_fts
+          inner join lemmas lm on lm.id = lemmas_fts.rowid
+          ${needTagFilter
+            ? db.raw`inner join (
+              select
+                d.lemma_id as lemma_id,
+                count(distinct dt.tag_id) as tag_count
+              from definition_tags dt
+              inner join definitions d on d.id = dt.definition_id
+              where dt.tag_id in (${filters.withTags})
+              group by d.lemma_id
+            ) tc on tc.lemma_id = lm.id`
+            : EmptySql}
+          where lemmas_fts match ${ftsQuery}
+          ${filters.inLanguages
+            ? db.raw`and lm.language_id in (${filters.inLanguages})`
+            : EmptySql}
+          ${filters.inPartsOfSpeech
+            ? db.raw`and exists(
+              select 1
+              from definitions d
+              where d.lemma_id = lm.id
+                and d.part_of_speech_id in (${filters.inPartsOfSpeech})
+            )`
+            : EmptySql}
+          ${needTagFilter && filters.tagMatching === 'MATCH_ALL'
+            ? db.raw`and tc.tag_count = ${filters.withTags!.length}`
+            : EmptySql}
+        `,
+      };
+    },
+  },
+  SEARCH_DEFINITIONS: {
+    acceptsLanguageFilter: true,
+    acceptsPartOfSpeechFilter: true,
+    acceptsTagFilter: true,
+    buildSql(db, ftsQuery, filters) {
+      const needTagFilter = filters.withTags && filters.withTags.length > 0;
+      return {
+        fields: db.raw`
+          'definition' as kind,
+          d.id as id,
+          snippet(definitions_fts, 0, ${SnippetArgs}) as matching_snippet,
+          definitions_fts.rank as score
+        `,
+        fromJoinWhere: db.raw`
+          from definitions_fts
+          inner join definitions d on d.id = definitions_fts.rowid
+          ${needTagFilter
+            ? db.raw`inner join (
+              select
+                dt.definition_id as definition_id,
+                count(dt.tag_id) as tag_count
+              from definition_tags dt
+              where dt.tag_id in (${filters.withTags})
+              group by dt.definition_id
+            ) tc on tc.definition_id = d.id`
+            : EmptySql}
+          where definitions_fts match ${ftsQuery}
+          ${filters.inLanguages
+            ? db.raw`and d.language_id in (${filters.inLanguages})`
+            : EmptySql}
+          ${filters.inPartsOfSpeech
+            ? db.raw`and d.part_of_speech_id in (${filters.inPartsOfSpeech})`
+            : EmptySql}
+          ${needTagFilter && filters.tagMatching === 'MATCH_ALL'
+            ? db.raw`and tc.tag_count = ${filters.withTags!.length}`
+            : EmptySql}
+        `,
+      };
+    },
+  },
+  SEARCH_PARTS_OF_SPEECH: {
+    acceptsLanguageFilter: true,
+    buildSql(db, ftsQuery, filters) {
+      return {
+        fields: db.raw`
+          'part_of_speech' as kind,
+          pos.id as id,
+          snippet(parts_of_speech_fts, 0, ${SnippetArgs}) as matching_snippet,
+          parts_of_speech_fts.rank as score
+        `,
+        fromJoinWhere: db.raw`
+          from parts_of_speech_fts
+          inner join parts_of_speech pos on pos.id = parts_of_speech_fts.rowid
+          where parts_of_speech_fts match ${ftsQuery}
+          ${filters.inLanguages
+            ? db.raw`and pos.language_id in (${filters.inLanguages})`
+            : EmptySql}
+        `,
+      };
+    },
+  },
+  SEARCH_TAGS: {
+    buildSql(db, ftsQuery) {
+      return {
+        fields: db.raw`
+          'tag' as kind,
+          t.id as id,
+          snippet(tags_fts, 0, ${SnippetArgs}) as matching_snippet,
+          tags_fts.rank as score
+        `,
+        fromJoinWhere: db.raw`
+          from tags_fts
+          inner join tags t on t.id = tags_fts.rowid
+          where tags_fts match ${ftsQuery}
+        `,
+      };
+    },
+  },
+};
+/* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+export const findValidScopes = (
+  scopes: readonly SearchScope[],
+  filters: SearchFilters
+): Set<SearchScope> =>
+  new Set(scopes.filter(scope => {
+    const scopeInfo = AllScopeInfo[scope];
+    return (
+      (!filters.inLanguages || scopeInfo.acceptsLanguageFilter) &&
+      (!filters.inPartsOfSpeech || scopeInfo.acceptsPartOfSpeechFilter) &&
+      (!filters.withTags || scopeInfo.acceptsTagFilter)
+    );
+  }));
+
+export const buildSearchSql = (
+  db: DataReader,
+  ftsQuery: string,
+  scopes: Set<SearchScope>,
+  filters: SearchFilters
+): ScopeSql[] => {
+  const result: ScopeSql[] = [];
+
+  for (const scope of scopes) {
+    const scopeInfo = AllScopeInfo[scope];
+    result.push(scopeInfo.buildSql(db, ftsQuery, filters));
+  }
+
+  return result;
+};

--- a/packages/server/src/model/search-index/snippet.ts
+++ b/packages/server/src/model/search-index/snippet.ts
@@ -1,0 +1,15 @@
+// Characters from the Private Use Area are employed as markers. The code
+// points chosen are totally arbitrary and basically just an attempt at
+// picking something that is likely to be unique.
+
+/**
+ * Indicates that the beginning or end of a snippet is partial; that is, there
+ * is text beyond the snippet.
+ */
+export const Partial = '\uE642\uEA00';
+
+/** Indicates the start of a matching phrase. */
+export const MatchStart = '\uE642\uEA01';
+
+/** Indicates the end of a matching phrase. */
+export const MatchEnd = '\uE642\uEA02';

--- a/packages/server/src/model/search-index/types.ts
+++ b/packages/server/src/model/search-index/types.ts
@@ -1,0 +1,76 @@
+import {
+  LanguageId,
+  LemmaId,
+  DefinitionId,
+  PartOfSpeechId,
+  TagId,
+  MatchingMode,
+} from '../../graphql';
+
+export type SearchResultRow =
+  | LanguageSearchResultRow
+  | LemmaSearchResultRow
+  | DefinitionSearchResultRow
+  | PartOfSpeechSearchResultRow
+  | TagSearchResultRow;
+
+// These types have names for snippet fields that are deliberately chosen to be
+// different from the GraphQL schema's field names, so we get type errors if we
+// forget to implement resolvers for them.
+
+export type LanguageSearchResultRow = {
+  kind: 'language';
+  id: LanguageId;
+  /** Name snippet. */
+  matching_snippet: string;
+  score: number;
+};
+
+export type LemmaSearchResultRow = {
+  kind: 'lemma';
+  id: LemmaId;
+  /** Term snippet. */
+  matching_snippet: string;
+  score: number;
+};
+
+export type DefinitionSearchResultRow = {
+  kind: 'definition';
+  id: DefinitionId;
+  /** Description snippet. */
+  matching_snippet: string;
+  score: number;
+};
+
+export type PartOfSpeechSearchResultRow = {
+  kind: 'part_of_speech';
+  id: PartOfSpeechId;
+  /** Name snippet. */
+  matching_snippet: string;
+  score: number;
+};
+
+export type TagSearchResultRow = {
+  kind: 'tag';
+  id: TagId;
+  /** Name snippet. */
+  matching_snippet: string;
+  score: number;
+};
+
+export type SearchFilters = {
+  inLanguages: readonly LanguageId[] | null;
+  inPartsOfSpeech: readonly PartOfSpeechId[] | null;
+  withTags: readonly TagId[] | null;
+  tagMatching: MatchingMode;
+};
+
+export type LemmaSearchIndexInput = {
+  readonly id: LemmaId;
+  readonly term: string;
+};
+
+export type TagSearchIndexInput = {
+  readonly id: TagId;
+  readonly name: string;
+};

--- a/packages/server/src/model/tag/mut.ts
+++ b/packages/server/src/model/tag/mut.ts
@@ -1,19 +1,25 @@
 import {DataWriter} from '../../database';
 import {TagId} from '../../graphql';
 
+import {SearchIndexMut} from '../search-index';
+
 import {Tag} from './model';
-import {TagRow} from './types';
 import {ValidTag} from './validators';
 
 const TagMut = {
   ensureAllExist(db: DataWriter, tags: ValidTag[]): Map<string, TagId> {
+    type Row = {
+      id: TagId;
+      name: string;
+    };
+
     if (tags.length === 0) {
       // Nothing to do
       return new Map<string, TagId>();
     }
 
-    const result = db.all<TagRow>`
-      select *
+    const result = db.all<Row>`
+      select id, name
       from tags
       where name in (${tags})
     `;
@@ -21,36 +27,46 @@ const TagMut = {
       result.map(row => [row.name, row.id])
     );
 
-    for (const tag of tags) {
-      // TODO: Can we parallelise this? Auto-increment IDs *should* be serial.
-      if (!tagToId.has(tag)) {
-        const {insertId} = db.exec<TagId>`
-          insert into tags (name)
-          values (${tag})
-        `;
-        tagToId.set(tag, insertId);
+    const newNames = tags.filter(t => !tagToId.has(t));
+    if (newNames.length > 0) {
+      const newTags = db.all<Row>`
+        insert into tags (name)
+        values ${newNames.map(n => db.raw`(${n})`)}
+        returning id, name
+      `;
+
+      for (const tag of newTags) {
+        tagToId.set(tag.name, tag.id);
       }
+
+      SearchIndexMut.insertTags(db, newTags);
     }
 
     return tagToId;
   },
 
   deleteOrphaned(db: DataWriter): void {
-    const emptyIds = db.all<{id: TagId}>`
-      select t.id
-      from tags t
-      left join definition_tags dt on dt.tag_id = t.id
-      where dt.definition_id is null
-      group by t.id
+    const deleted = db.all<{id: TagId}>`
+      with orphaned_tags(id) as (
+        select t.id
+        from tags t
+        left join definition_tags dt on dt.tag_id = t.id
+        where dt.definition_id is null
+        group by t.id
+      )
+      delete from tags
+      where id in (select id from orphaned_tags)
+      returning id
     `;
 
-    if (emptyIds.length > 0) {
-      emptyIds.forEach(row => db.clearCache(Tag.byIdKey, row.id));
+    if (deleted.length > 0) {
+      const ids = deleted.map(d => d.id);
 
-      db.exec`
-        delete from tags
-        where id in (${emptyIds.map(row => row.id)})
-      `;
+      for (const id of ids) {
+        db.clearCache(Tag.byIdKey, id);
+      }
+
+      SearchIndexMut.deleteTags(db, ids);
     }
   },
 } as const;


### PR DESCRIPTION
This pull request adds a first version of full-text search and filtering to `@condict/server`. Being a first version, the implementation is kind of rough and has a bit of new project smell. The actual search features are limited largely by SQLite's capabilities. There are several things worth noting:

* The chosen token characters – Unicode categories `L* N* Co Mc Mn` and the character `'` – are almost guaranteed to be wrong for certain languages. These characters were chosen as a hopefully reasonable middle ground sort of thing. Also, diacritics are _preserved_, which is almost certainly exactly as annoying and wrong as stripping them would be. There's just no way to get perfect per-language behaviour without a custom tokeniser and one table per language, basically.
* SQLite's full-text search only supports searching by full tokens and token prefixes. A word like `foobar` cannot be found by searching for `bar`. This may present problems for some languages.
* Matching snippet highlights are based on tokens. Given a word `foo barbaz`, a search for `bar` would highlight the entire `barbaz` token, as in _foo **barbaz**_.
* Each searchable resource (languages, lemmas, definitions, etc.) has its own FTS table, and the results from each table are unioned together and then sorted. This may produce weird search result orderings. I may fix this in the future, but I'm not sure how to do it without combining everything into one table.
* Descriptions are indexed in their entirety. There is no ability to mark parts of a description as non-searchable. This may be changed in future updates.

The search index is maintained by its own `SearchIndexMut` type, rather than being placed under each searchable resource. These functions are called from the mutators of searchable resources.

In addition to the new search features, this PR also includes a few small changes to how lemmas and tags are created. We now take advantage of the `RETURNING` clause, which the latest version of `better-sqlite3` has support for, in order to insert multiple rows in a single query and return the new IDs (and other details). Extremely useful.

And lastly, two small changes were made to the logging:

* Queries are logged before statements are prepared, which makes it much easier to diagnose syntax errors.
* Request IDs are prepended to messages logged by each request. When log messages from multiple requests are intertwined, this makes it much easier to see which request logged what.