### PR TITLE
Decouple inflection tables from pos

### DIFF
--- a/graphql-schema/definition.graphql
+++ b/graphql-schema/definition.graphql
@@ -7,8 +7,6 @@ speech, a description, and, optionally, some inflection tables.
 
 A definition's description contains free-form formatted text. Paragraphs, list
 items, headings and other things.
-
-A definition's inflection tables must belong to the definition's part of speech.
 """
 type Definition implements RecentItem {
   "The globally unique ID of the definition."
@@ -268,14 +266,7 @@ input EditDefinitionInput {
   "If set, updates the definition term."
   term: String
 
-  """
-  If set, updates the part of speech.
-
-  If this field is set to a value other than the definition's current part of
-  speech, and `inflectionTables` is _not_ set, then the definition's inflection
-  tables will all be deleted. In other words, changing the part of speech will
-  delete inflection tables unless you specify new ones.
-  """
+  "If set, updates the part of speech."
   partOfSpeechId: PartOfSpeechId
 
   "If set, updates the definition description."

--- a/graphql-schema/inflection-table.graphql
+++ b/graphql-schema/inflection-table.graphql
@@ -2,28 +2,34 @@
 scalar InflectionTableId @id
 
 """
-An inflection table defines how to inflect words that belong to the table's part
-of speech. The table is a true 2-dimensional table, not merely a list of forms.
-As such, it can contain any number of rows and columns, and some cells may be
-headers. Cells can span multiple rows and columns.
+An inflection table defines how to inflect definitions. The table is a true
+2-dimensional table, not merely a list of forms. As such, it can contain any
+number of rows and columns, and some cells may be headers. Cells can span
+multiple rows and columns.
 
 To access the contents of an inflection table, query the `layout` field. Through
 it, you can read the table's rows and cells to construct the table, fetch the
 inflected forms (see `InflectedForm`) that are contained in the table, as well
 as query the definitions that use the table layout.
 
-In addition to the current table layout, inflection tables record some historical
-layouts. If the layout is altered while it is in use by one or more definitions,
-the previous layout is kept, allowing existing definitions to keep using it. Old
-layouts are available through the `oldLayouts` field.
+## Historical layouts
 
-Historical layouts are saved for two reasons:
+If you change the layout of a table that is used by one or more definitions, the
+previous layout may be kept. The precise conditions are not specified here, but
+the rule of thumb is this: if the new layout would cause derived forms to be
+added, edited or removed, the old layout is kept.
+
+Historical layouts are saved in order to prevent potential dictionary-wide
+alterations:
 
 1. Inflected forms may be added to the dictionary (see `InflectedForm`), and
-   recalculating new forms for every definition that uses a table is costly.
+   recalculating new forms for every definition that uses a table may be costly.
 2. It is exceedingly difficult for the user to predict the effect of altering
    an inflection table across the entire dictionary, especially if the table is
-   used by many definitions.
+   used by many definitions. By forcing the user to update definitions manually,
+   we effectively make them check each one.
+
+Old layouts are available through the `oldLayouts` field.
 """
 type InflectionTable implements RecentItem {
   "The globally unique ID of the inflection table."
@@ -50,8 +56,8 @@ type InflectionTable implements RecentItem {
   """
   oldLayouts(page: PageParams): InflectionTableLayoutConnection!
 
-  "The part of speech that this inflection table belongs to."
-  partOfSpeech: PartOfSpeech!
+  "The language that this inflection table belongs to."
+  language: Language!
 
   """
   Indicates whether any version of the inflection table is currently used by any
@@ -321,8 +327,8 @@ extend type Query {
 
 "Input type for a new inflection table."
 input NewInflectionTableInput {
-  "The part of speech that the inflection table will be added to."
-  partOfSpeechId: PartOfSpeechId!
+  "The language that the inflection table will be added to."
+  languageId: LanguageId!
 
   "The name of the inflection table."
   name: String!
@@ -336,7 +342,7 @@ input NewInflectionTableInput {
 
 """
 Input type for editing an existing inflection table. It is not possible to move
-an inflection table to another part of speech.
+an inflection table to another language.
 """
 input EditInflectionTableInput {
   "If set, renames the inflection table."

--- a/graphql-schema/language.graphql
+++ b/graphql-schema/language.graphql
@@ -16,8 +16,8 @@ input LemmaFilter {
   For direct definitions (those in `Lemma.definitions`), the lemma matches if
   at least one definition belongs to one of the specified parts of speech. For
   derived definitions (in `Lemma.derivedDefinitions`), the lemma matches if
-  the derived definition comes from an inflected form in one of the specified
-  parts of speech.
+  the derived definition comes from an original definition of the specified
+  part of speech.
 
   If this parameter is the empty list, no lemmas are returned.
   """
@@ -96,10 +96,11 @@ number of languages.
 A language contains:
 
 * Parts of speech (see `PartOfSpeech`), which words can be associated with.
-  Each part of speech can contain any number of inflection tables (see
-  `InflectionTable`).
+* Inflection tables (see `InflectionTable`), which specifies how definitions
+  inflect.
 * Lemmas (see `Lemma`), which are basically the words of the dictionary. Each
-  lemma can contain any number of definitions (see `Definition`).
+  lemma can contain any number of definitions (see `Definition`). Lemmas should
+  have been called _headwords_.
 
 In addition, every language has a (unique) name, an optional description, and
 various metadata.
@@ -125,6 +126,12 @@ type Language implements RecentItem {
 
   "Finds a part of speech by name."
   partOfSpeechByName(name: String!): PartOfSpeech
+
+  "The inflection tables that belong to this language."
+  inflectionTables: [InflectionTable!]!
+
+  "Finds an inflection table by name."
+  inflectionTableByName(name: String!): InflectionTable
 
   "The total number of lemmas in the dictionary."
   lemmaCount: Int!
@@ -210,7 +217,7 @@ type Language implements RecentItem {
   """
   The time of the most recent update to the language. This time coers updates
   performed on the language itself, but not on any of its subresources (such as
-  parts of speech or definitions).
+  parts of speech, inflection tables or definitions).
   """
   timeUpdated: UtcInstant!
 

--- a/graphql-schema/part-of-speech.graphql
+++ b/graphql-schema/part-of-speech.graphql
@@ -2,10 +2,9 @@
 scalar PartOfSpeechId @id
 
 """
-A part of speech is associated with each word in the dictionary. In addition to
-providing a way to group words, a part of speech can define any number of
-inflection tables, which describe how to inflect words in that part of speech.
-See `InflectionTable` for more.
+A part of speech is associated with each word in the dictionary. It is possible
+to search and filter definitions by part of speech, and every definition must
+belong to a part of speech.
 """
 type PartOfSpeech implements RecentItem {
   "The globally unique ID of the part of speech."
@@ -13,12 +12,6 @@ type PartOfSpeech implements RecentItem {
 
   "The display name of the part of speech."
   name: String!
-
-  "The inflection tables defined in this part of speech."
-  inflectionTables: [InflectionTable!]!
-
-  "Finds an inflection table by name."
-  inflectionTableByName(name: String!): InflectionTable
 
   "The language that the part of speech belongs to."
   language: Language!
@@ -46,11 +39,7 @@ type PartOfSpeech implements RecentItem {
   "The time that the part of speech was created."
   timeCreated: UtcInstant!
 
-  """
-  The time of the most recent update to the part of speech. This time covers
-  updates performed on the part of speech itself, but not to any of its
-  inflection tables.
-  """
+  "The time of the most recent update to the part of speech."
   timeUpdated: UtcInstant!
 
   "Assorted statistics about a part of speech."
@@ -59,9 +48,6 @@ type PartOfSpeech implements RecentItem {
 
 "Contains statistics about a part of speech."
 type PartOfSpeechStats {
-  "The number of inflection tables in the part of speech."
-  inflectionTableCount: Int!
-
   "The total number of definitions that use the part of speech."
   definitionCount: Int!
 }

--- a/packages/app/locale/en.ftl
+++ b/packages/app/locale/en.ftl
@@ -558,15 +558,9 @@ table-editor-rename-forms = Edit all form names...
 
 table-editor-import-layout-title = Import layout
 
-table-editor-import-same-pos-heading = From the same part of speech
-
-table-editor-import-same-pos-empty = There are no other inflection tables in this part of speech.
-
-table-editor-import-other-pos-heading = From another part of speech
-
-table-editor-import-other-pos-empty = There are no inflection tables in any other part of speech in this language.
-
 table-editor-import-open-table-button = View the table in a new tab
+
+table-editor-import-no-other-tables = There are no other inflection tables in this language.
 
 table-editor-import-error = The selected table could not be loaded. It may help to try again.
 
@@ -699,13 +693,10 @@ home-recent-definition-description = Definition in <lang-link>{$language}</lang-
 home-recent-part-of-speech-description = Part of speech in <lang-link>{$language}</lang-link>
 
 # Variables:
-#   partOfSpeech: The name of the part of speech that the inflection table belongs to.
 #   language: The name of the language that the inflection table is in.
 # Elements:
-#   <pos-link>: Link to the part of speech that the inflection table belongs to. Wraps around $partOfSpeech.
 #   <lang-link>: Link to the language that the definition is in. Wraps around $language.
-home-recent-inflection-table-description =
-    Inflection table of <pos-link>{$partOfSpeech}</pos-link> in <lang-link>{$language}</lang-link>
+home-recent-inflection-table-description = Inflection table in <lang-link>{$language}</lang-link>
 
 home-recent-added-on = Added {DATETIME($time, dateStyle: "short", timeStyle: "short")}
 
@@ -747,24 +738,6 @@ language-recent-definitions-heading = Recent definitions
 
 language-parts-of-speech-heading = Parts of speech
 
-language-add-part-of-speech-button = Add part of speech
-
-language-no-parts-of-speech-description =
-  There are no parts of speech in this language. Parts of speech are a way to group your words. They can also contain inflection rules for words.
-
-language-tags-heading = Tags
-
-language-no-tags-description = The definitions in this language do not have any tags. You can add tags to a definition when you create or edit it.
-
-# Variables:
-#   tableCount: The total number of inflection tables in the part of speech.
-language-part-of-speech-tables =
-  {$tableCount ->
-    [0] No inflection tables
-    [one] {$tableCount} inflection table
-   *[other] {$tableCount} inflection tables
-  }
-
 # Variables:
 #   definitionCount: The total number of definitions that use the part of speech.
 language-part-of-speech-used-by-definitions =
@@ -773,6 +746,28 @@ language-part-of-speech-used-by-definitions =
     [one] Used by {$definitionCount} definition
    *[other] Used by {$definitionCount} definitions
   }
+
+language-add-part-of-speech-button = Add part of speech
+
+language-no-parts-of-speech-description =
+  There are no parts of speech in this language. Parts of speech are a way to group your words. You can also search for words by part of speech.
+
+language-tables-heading = Inflection tables
+
+language-table-used-by-definitions =
+  {$definitionCount ->
+    [0] Not used by any definitions
+    [one] Used by {$definitionCount} definition
+   *[other] Used by {$definitionCount} definitions
+  }
+
+language-add-table-button = Add inflection table
+
+language-no-tables-description = There are no inflection tables in this language. Inflection tables can be added to a word to display its inflected forms. Inflected forms can also be added to the dictionary as searchable terms.
+
+language-tags-heading = Tags
+
+language-no-tags-description = The definitions in this language do not have any tags. You can add tags to a definition when you create or edit it.
 
 language-added-on = Added {DATETIME($time, dateStyle: "short", timeStyle: "short")}
 
@@ -946,8 +941,6 @@ definition-table-has-new-version-notice = A new version of this table is availab
 
 definition-table-needs-new-version-error = A new version of this table is available. The table must be updated before you save the definition.
 
-definition-table-wrong-part-of-speech-error = This table belongs to a different part of speech. It cannot be added to the definition.
-
 definition-table-deleted-error = This table has been deleted. It cannot be added to the definition.
 
 definition-upgrade-layout-button = Update to latest layout
@@ -955,8 +948,6 @@ definition-upgrade-layout-button = Update to latest layout
 definition-add-table-button = Add inflection table
 
 definition-new-table-menu = New inflection table...
-
-definition-tables-select-part-of-speech-helper = Select a part of speech to add inflections to this word.
 
 definition-stems-label = Inflection stems
 
@@ -1001,15 +992,6 @@ definition-not-found-error = Definition not found. This definition has been dele
 #   <lang-link>: Link to the language that the part of speech belongs to. Wraps around $language.
 part-of-speech-subheading = Part of speech in language <lang-link>{$language}</lang-link>
 
-part-of-speech-tables-heading = Inflection tables
-
-part-of-speech-table-used-by-definitions =
-  {$definitionCount ->
-    [0] Not used by any definitions
-    [one] Used by {$definitionCount} definition
-   *[other] Used by {$definitionCount} definitions
-  }
-
 part-of-speech-definitions-heading = Definitions of this part of speech
 
 part-of-speech-browse-definitions-title =
@@ -1024,10 +1006,6 @@ part-of-speech-added-on = Added {DATETIME($time, dateStyle: "short", timeStyle: 
 
 part-of-speech-edited-on = Edited {DATETIME($time, dateStyle: "short", timeStyle: "short")}
 
-part-of-speech-add-table-button = Add inflection table
-
-part-of-speech-no-tables-description = There are no inflection tables in this part of speech. Inflection tables can be added to a word to display its inflected forms. Inflected forms can also be added to the dictionary as searchable terms.
-
 part-of-speech-name-label = Name
 
 part-of-speech-name-required-error = A part of speech name is required.
@@ -1040,7 +1018,7 @@ part-of-speech-delete-title = Delete part of speech
 
 # Elements:
 #   <bold>: Bold text.
-part-of-speech-delete-confirm = The part of speech and all inflection tables in it will be deleted. This <bold>cannot be undone</bold>.
+part-of-speech-delete-confirm = The part of speech will be deleted. This <bold>cannot be undone</bold>.
 
 # Variables:
 #   definitionCount: The total number of definitions that use the part of speech.
@@ -1053,7 +1031,7 @@ part-of-speech-delete-not-possible =
      *[other] {$definitionCount} definitions
     }.
 
-part-of-speech-delete-button = Delete part of speech and tables
+part-of-speech-delete-button = Delete part of speech
 
 part-of-speech-delete-error = An error occurred when deleting the part of speech. It may help to try again.
 
@@ -1066,13 +1044,11 @@ part-of-speech-add-table-title = Add inflection table
 ## Inflection table messages
 
 # Variables:
-#   partOfSpeech: The name of the part of speech that the table belongs to.
 #   language: The name of the language that the table belongs to.
 #
 # Elements:
-#   <pos-link>: Link to the part of speech that the table belongs to. Wraps around $partOfSpeech.
 #   <lang-link>: Link to the language that the table belongs to. Wraps around $language.
-inflection-table-subheading = Inflection table in part of speech <pos-link>{$partOfSpeech}</pos-link>, in language <lang-link>{$language}</lang-link>
+inflection-table-subheading = Inflection table in language <lang-link>{$language}</lang-link>
 
 inflection-table-layout-heading = Layout
 

--- a/packages/app/src/main/server/parse-json.ts
+++ b/packages/app/src/main/server/parse-json.ts
@@ -100,12 +100,8 @@ const parseEvent = (value: unknown, index: number): DictionaryEvent => {
     }
     case 'inflectionTable': {
       const id = parseId(value.id, `${path}.id`);
-      const partOfSpeechId = parseId(
-        value.partOfSpeechId,
-        `${path}.partOfSpeechId`
-      );
       const languageId = parseId(value.languageId, `${path}.languageId`);
-      return {type: 'inflectionTable', action, id, partOfSpeechId, languageId};
+      return {type: 'inflectionTable', action, id, languageId};
     }
     case 'tag': {
       const id = parseId(value.id, `${path}.id`);

--- a/packages/app/src/renderer/form-fields/inflection-table-field/index.tsx
+++ b/packages/app/src/renderer/form-fields/inflection-table-field/index.tsx
@@ -9,7 +9,7 @@ import {
 
 import {useNearestForm, useField, useFormState} from '../../form';
 import {useTableEditorMessages} from '../../hooks';
-import {LanguageId, PartOfSpeechId, InflectionTableId} from '../../graphql';
+import {LanguageId, InflectionTableId} from '../../graphql';
 
 import {HistoryValue, useHistoryCommands} from '../history-value';
 import * as S from '../styles';
@@ -21,7 +21,6 @@ export type Props = {
   path?: string;
   label?: ReactNode;
   languageId: LanguageId;
-  partOfSpeechId: PartOfSpeechId;
   inflectionTableId: InflectionTableId | null;
   errorMessage?: ReactNode;
 } & Omit<
@@ -43,7 +42,6 @@ export const InflectionTableField = React.memo((props: Props): JSX.Element => {
     path,
     label,
     languageId,
-    partOfSpeechId,
     inflectionTableId,
     errorMessage,
     disabled,
@@ -114,7 +112,6 @@ export const InflectionTableField = React.memo((props: Props): JSX.Element => {
               canRedo={history.redo.length > 0}
               valueRef={history}
               languageId={languageId}
-              partOfSpeechId={partOfSpeechId}
               inflectionTableId={inflectionTableId}
               onChange={handleChange}
             />

--- a/packages/app/src/renderer/form-fields/inflection-table-field/query.graphql
+++ b/packages/app/src/renderer/form-fields/inflection-table-field/query.graphql
@@ -3,14 +3,9 @@ query AllTableLayoutsQuery($lang: LanguageId!) {
     id
     name
 
-    partsOfSpeech {
+    inflectionTables {
       id
       name
-
-      inflectionTables {
-        id
-        name
-      }
     }
   }
 }

--- a/packages/app/src/renderer/form-fields/inflection-table-field/query.ts
+++ b/packages/app/src/renderer/form-fields/inflection-table-field/query.ts
@@ -5,23 +5,18 @@
 import {
   Query,
   LanguageId,
-  PartOfSpeechId,
   InflectionTableId
 } from "../../graphql";
 
-export const AllTableLayoutsQuery = "query AllTableLayoutsQuery($lang:LanguageId!){language(id:$lang){id,name,partsOfSpeech{id,name,inflectionTables{id,name}}}}" as Query<{
+export const AllTableLayoutsQuery = "query AllTableLayoutsQuery($lang:LanguageId!){language(id:$lang){id,name,inflectionTables{id,name}}}" as Query<{
   lang: LanguageId;
 }, {
   language: {
     id: LanguageId;
     name: string;
-    partsOfSpeech: {
-      id: PartOfSpeechId;
+    inflectionTables: {
+      id: InflectionTableId;
       name: string;
-      inflectionTables: {
-        id: InflectionTableId;
-        name: string;
-      }[];
     }[];
   } | null;
 }>;

--- a/packages/app/src/renderer/form-fields/inflection-table-field/toolbar.tsx
+++ b/packages/app/src/renderer/form-fields/inflection-table-field/toolbar.tsx
@@ -19,7 +19,7 @@ import {Toolbar, Menu} from '@condict/ui';
 import {InflectionTable, SelectionShape} from '@condict/table-editor';
 
 import {useOpenPanel} from '../../navigation';
-import {InflectionTableId, LanguageId, PartOfSpeechId} from '../../graphql';
+import {InflectionTableId, LanguageId} from '../../graphql';
 
 import * as S from '../styles';
 
@@ -33,7 +33,6 @@ type Props = {
   canRedo: boolean;
   valueRef: { current: InflectionTable };
   languageId: LanguageId;
-  partOfSpeechId: PartOfSpeechId;
   inflectionTableId: InflectionTableId | null;
   onChange: (table: InflectionTable) => void;
 };
@@ -49,7 +48,6 @@ const TableToolbar = React.memo((props: Props): JSX.Element => {
     canRedo,
     valueRef,
     languageId,
-    partOfSpeechId,
     inflectionTableId,
     onChange,
   } = props;
@@ -69,7 +67,6 @@ const TableToolbar = React.memo((props: Props): JSX.Element => {
   const handleImportLayout = useCallback(() => {
     void openPanel(importLayoutPanel({
       languageId,
-      partOfSpeechId,
       inflectionTableId,
     })).then(value => {
       if (value) {
@@ -78,7 +75,6 @@ const TableToolbar = React.memo((props: Props): JSX.Element => {
     });
   }, [
     languageId,
-    partOfSpeechId,
     inflectionTableId,
     openPanel,
     onChange,

--- a/packages/app/src/renderer/forms/definition/active-stem-names.ts
+++ b/packages/app/src/renderer/forms/definition/active-stem-names.ts
@@ -1,46 +1,21 @@
 import {useMemo} from 'react';
 
 import {Form, useFormValue} from '../../form';
-import {PartOfSpeechId, InflectionTableId} from '../../graphql';
 
 import NeutralCollator from './neutral-collator';
-import {DefinitionTableFormData, PartOfSpeechFields} from './types';
+import {DefinitionTableFormData} from './types';
 
-const useActiveStemNames = (
-  form: Form<any>,
-  partsOfSpeech: readonly PartOfSpeechFields[]
-): string[] => {
-  const partOfSpeechId = useFormValue<PartOfSpeechId | null>(
-    form,
-    'partOfSpeech'
-  );
+const useActiveStemNames = (form: Form<any>): string[] => {
   const inflectionTables = useFormValue<DefinitionTableFormData[]>(
     form,
     'inflectionTables'
   );
 
-  const availableTables = useMemo(() => {
-    const pos = partsOfSpeech.find(p => p.id === partOfSpeechId);
-    if (!pos) {
-      return new Set<InflectionTableId>();
-    }
-    return new Set(pos.inflectionTables.map(t => t.id));
-  }, [partsOfSpeech, partOfSpeechId]);
-
   return useMemo(() => {
-    // Clear this so we can rebuild it below.
-    if (partOfSpeechId == null) {
-      return [];
-    }
-
     const active: string[] = [];
 
     const seen = new Set<string>();
     for (const table of inflectionTables) {
-      if (!availableTables.has(table.tableId)) {
-        // The table belongs to a different part of speech; ignore it.
-        continue;
-      }
       for (const name of table.stems) {
         if (!seen.has(name)) {
           active.push(name);
@@ -52,7 +27,7 @@ const useActiveStemNames = (
     // eslint-disable-next-line @typescript-eslint/unbound-method
     active.sort(NeutralCollator.compare);
     return active;
-  }, [availableTables, inflectionTables]);
+  }, [inflectionTables]);
 };
 
 export default useActiveStemNames;

--- a/packages/app/src/renderer/forms/definition/fragment.graphql
+++ b/packages/app/src/renderer/forms/definition/fragment.graphql
@@ -2,16 +2,18 @@ fragment DefinitionFormPartsOfSpeechFragment on Language {
   partsOfSpeech {
     id
     name
+  }
+}
 
-    inflectionTables {
+fragment DefinitionFormInflectionTablesFragment on Language {
+  inflectionTables {
+    id
+    name
+
+    layout {
       id
-      name
-
-      layout {
-        id
-        stems
-        ...DefinitionTableFragment
-      }
+      stems
+      ...DefinitionTableFragment
     }
   }
 }

--- a/packages/app/src/renderer/forms/definition/inflection-table-options.tsx
+++ b/packages/app/src/renderer/forms/definition/inflection-table-options.tsx
@@ -1,0 +1,54 @@
+import {useState, useRef} from 'react';
+
+import {useExecute, useDictionaryEvents} from '../../data';
+import {LanguageId} from '../../graphql';
+
+import {AllInflectionTablesQuery} from './query';
+import {InflectionTableFields} from './types';
+
+export type Options = {
+  languageId: LanguageId;
+  initialInflectionTables: readonly InflectionTableFields[];
+};
+
+const useInflectionTableOptions = ({
+  languageId,
+  initialInflectionTables,
+}: Options): readonly InflectionTableFields[] => {
+  const [inflectionTables, setInflectionTables] = useState(initialInflectionTables);
+
+  const execute = useExecute();
+
+  const requestId = useRef(0);
+  useDictionaryEvents(({events}) => {
+    const needRefetch = events.some(event =>
+      event.type === 'inflectionTable' &&
+      event.languageId === languageId
+    );
+    if (!needRefetch) {
+      return;
+    }
+
+    const id = ++requestId.current;
+    void execute(AllInflectionTablesQuery, {lang: languageId}).then(result => {
+      if (result.errors) {
+        console.error('Error fetching inflection tables:', result.errors);
+        return;
+      }
+
+      if (id !== requestId.current) {
+        // Old request; ignore results.
+        return;
+      }
+
+      // If there were no errors, there should be a result. If the language
+      // has been deleted, just use an empty list.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      setInflectionTables(result.data!.language?.inflectionTables ?? []);
+    });
+  });
+
+  return inflectionTables;
+};
+
+export default useInflectionTableOptions;

--- a/packages/app/src/renderer/forms/definition/part-of-speech-options.tsx
+++ b/packages/app/src/renderer/forms/definition/part-of-speech-options.tsx
@@ -1,4 +1,4 @@
-import {useState, useMemo, useCallback, useRef} from 'react';
+import {useState, useCallback, useRef} from 'react';
 import produce from 'immer';
 
 import {Form} from '../../form';
@@ -20,7 +20,6 @@ export type Options = {
 
 export interface PartOfSpeechOptions {
   partsOfSpeech: readonly PartOfSpeechFields[];
-  partOfSpeechOptions: JSX.Element[];
   handleCreatePartOfSpeech: () => void;
 }
 
@@ -49,8 +48,6 @@ const usePartOfSpeechOptions = ({
             draft.push({
               id: newPos.id,
               name: newPos.name,
-              // Brand new part of speech can't have any tables.
-              inflectionTables: [],
             });
             // Sort the list so the options end up in the order they'll probably
             // be in once we reload.
@@ -68,10 +65,8 @@ const usePartOfSpeechOptions = ({
   const requestId = useRef(0);
   useDictionaryEvents(({events}) => {
     const needRefetch = events.some(event =>
-      (
-        event.type === 'partOfSpeech' ||
-        event.type === 'inflectionTable'
-      ) && event.languageId === languageId
+      event.type === 'partOfSpeech' &&
+      event.languageId === languageId
     );
     if (!needRefetch) {
       return;
@@ -106,17 +101,8 @@ const usePartOfSpeechOptions = ({
     });
   });
 
-  const partOfSpeechOptions = useMemo<JSX.Element[]>(() => {
-    return partsOfSpeech.map(pos =>
-      <option key={pos.id} value={String(pos.id)}>
-        {pos.name}
-      </option>
-    );
-  }, [partsOfSpeech]);
-
   return {
     partsOfSpeech,
-    partOfSpeechOptions,
     handleCreatePartOfSpeech,
   };
 };

--- a/packages/app/src/renderer/forms/definition/query.graphql
+++ b/packages/app/src/renderer/forms/definition/query.graphql
@@ -3,3 +3,9 @@ query AllPartsOfSpeechQuery($lang: LanguageId!) {
     ...DefinitionFormPartsOfSpeechFragment
   }
 }
+
+query AllInflectionTablesQuery($lang: LanguageId!) {
+  language(id: $lang) {
+    ...DefinitionFormInflectionTablesFragment
+  }
+}

--- a/packages/app/src/renderer/forms/definition/query.ts
+++ b/packages/app/src/renderer/forms/definition/query.ts
@@ -11,36 +11,43 @@ import {
   InflectedFormId
 } from "../../graphql";
 
-export const AllPartsOfSpeechQuery = "query AllPartsOfSpeechQuery($lang:LanguageId!){language(id:$lang){...DefinitionFormPartsOfSpeechFragment}}fragment DefinitionFormPartsOfSpeechFragment on Language{partsOfSpeech{id,name,inflectionTables{id,name,layout{id,stems...DefinitionTableFragment}}}}fragment DefinitionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}" as Query<{
+export const AllPartsOfSpeechQuery = "query AllPartsOfSpeechQuery($lang:LanguageId!){language(id:$lang){...DefinitionFormPartsOfSpeechFragment}}fragment DefinitionFormPartsOfSpeechFragment on Language{partsOfSpeech{id,name}}" as Query<{
   lang: LanguageId;
 }, {
   language: {
     partsOfSpeech: {
       id: PartOfSpeechId;
       name: string;
-      inflectionTables: {
-        id: InflectionTableId;
-        name: string;
-        layout: {
-          id: InflectionTableLayoutId;
-          stems: string[];
-          rows: {
-            cells: ({
-              rowSpan: number;
-              columnSpan: number;
-              inflectedForm: {
-                id: InflectedFormId;
-                inflectionPattern: string;
-                displayName: string;
-              };
-            } | {
-              rowSpan: number;
-              columnSpan: number;
-              headerText: string;
-            })[];
-          }[];
-        };
-      }[];
+    }[];
+  } | null;
+}>;
+
+export const AllInflectionTablesQuery = "query AllInflectionTablesQuery($lang:LanguageId!){language(id:$lang){...DefinitionFormInflectionTablesFragment}}fragment DefinitionFormInflectionTablesFragment on Language{inflectionTables{id,name,layout{id,stems...DefinitionTableFragment}}}fragment DefinitionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}" as Query<{
+  lang: LanguageId;
+}, {
+  language: {
+    inflectionTables: {
+      id: InflectionTableId;
+      name: string;
+      layout: {
+        id: InflectionTableLayoutId;
+        stems: string[];
+        rows: {
+          cells: ({
+            rowSpan: number;
+            columnSpan: number;
+            inflectedForm: {
+              id: InflectedFormId;
+              inflectionPattern: string;
+              displayName: string;
+            };
+          } | {
+            rowSpan: number;
+            columnSpan: number;
+            headerText: string;
+          })[];
+        }[];
+      };
     }[];
   } | null;
 }>;

--- a/packages/app/src/renderer/forms/definition/stems-field.tsx
+++ b/packages/app/src/renderer/forms/definition/stems-field.tsx
@@ -9,16 +9,9 @@ import {useNearestForm, useField, useFormValue, useFormState} from '../../form';
 import {Field, Label} from '../../form-fields';
 
 import useActiveStemNames from './active-stem-names';
-import {PartOfSpeechFields} from './types';
 import * as S from './styles';
 
-export type Props = {
-  partsOfSpeech: readonly PartOfSpeechFields[];
-};
-
-const StemsField = React.memo((props: Props): JSX.Element => {
-  const {partsOfSpeech} = props;
-
+const StemsField = React.memo((): JSX.Element => {
   const form = useNearestForm();
 
   const id = useUniqueId();
@@ -27,7 +20,7 @@ const StemsField = React.memo((props: Props): JSX.Element => {
   const field = useField<Map<string, string>>(form, 'stems');
 
   const term = useFormValue<string>(form, 'term');
-  const activeStems = useActiveStemNames(form, partsOfSpeech);
+  const activeStems = useActiveStemNames(form);
 
   const handleStemChange = (name: string, value: string | undefined) => {
     field.update(draft => {

--- a/packages/app/src/renderer/forms/definition/table-list.tsx
+++ b/packages/app/src/renderer/forms/definition/table-list.tsx
@@ -9,33 +9,23 @@ import {DefinitionTable} from '@condict/table-editor';
 
 import {useNearestForm, useField, useFormValue} from '../../form';
 import {Field, Label} from '../../form-fields';
-import {
-  PartOfSpeechId,
-  InflectionTableId,
-  InflectedFormId,
-} from '../../graphql';
+import {InflectionTableId, InflectedFormId} from '../../graphql';
 import type {NewInflectionTable} from '../../panels';
 
 import useTableReordering, {CurrentMovingState} from './table-reordering';
 import Table from './table';
-import {
-  DefinitionTableFormData,
-  PartOfSpeechFields,
-  InflectionTableInfo,
-} from './types';
+import {DefinitionTableFormData, InflectionTableFields} from './types';
 import * as S from './styles';
 
 export type Props = {
-  partsOfSpeech: readonly PartOfSpeechFields[];
-  onCreateInflectionTable: (
-    partOfSpeechId: PartOfSpeechId
-  ) => Promise<NewInflectionTable | null>;
+  inflectionTables: readonly InflectionTableFields[];
+  onCreateInflectionTable: () => Promise<NewInflectionTable | null>;
 };
 
 const EmptyCustomForms = new Map<InflectedFormId, string>();
 
 const TableList = React.memo((props: Props): JSX.Element => {
-  const {partsOfSpeech, onCreateInflectionTable} = props;
+  const {inflectionTables, onCreateInflectionTable} = props;
 
   const {l10n} = useLocalization();
 
@@ -76,58 +66,38 @@ const TableList = React.memo((props: Props): JSX.Element => {
     });
   }, []);
 
-  const partOfSpeechId = useFormValue<PartOfSpeechId | null>(
-    form,
-    'partOfSpeech'
-  );
-
   const inflectionTableMap = useMemo(() => {
-    const result = new Map<InflectionTableId, InflectionTableInfo>();
-    for (const pos of partsOfSpeech) {
-      for (const table of pos.inflectionTables) {
-        result.set(table.id, {
-          parent: pos.id,
-          table,
-        });
-      }
+    const result = new Map<InflectionTableId, InflectionTableFields>();
+    for (const table of inflectionTables) {
+      result.set(table.id, table);
     }
     return result;
-  }, [partsOfSpeech]);
+  }, [inflectionTables]);
 
-  const inflectionTableOptions = useMemo(() => {
-    const pos =
-      partOfSpeechId !== null &&
-      partsOfSpeech.find(p => p.id === partOfSpeechId);
-    if (!pos) {
-      return [];
-    }
-    return pos.inflectionTables.map(t =>
-      <Menu.Item
-        key={t.id}
-        label={t.name}
-        onActivate={() => addTable({
-          key: genUniqueId(),
-          id: null,
-          caption: emptyTableCaption(),
-          table: DefinitionTable.fromJson(
-            t.layout.rows,
-            EmptyCustomForms
-          ),
-          tableId: t.id,
-          layoutId: t.layout.id,
-          stems: t.layout.stems,
-          upgraded: false,
-        })}
-      />
-    );
-  }, [partsOfSpeech, partOfSpeechId]);
+  const inflectionTableOptions = useMemo(() => inflectionTables.map(t =>
+    <Menu.Item
+      key={t.id}
+      label={t.name}
+      onActivate={() => addTable({
+        key: genUniqueId(),
+        id: null,
+        caption: emptyTableCaption(),
+        table: DefinitionTable.fromJson(
+          t.layout.rows,
+          EmptyCustomForms
+        ),
+        tableId: t.id,
+        layoutId: t.layout.id,
+        stems: t.layout.stems,
+        upgraded: false,
+      })}
+    />
+  ), [inflectionTables]);
 
   const stems = useFormValue<Map<string, string>>(form, 'stems');
 
   const handleCreateInflectionTable = useCallback(() => {
-    // The menu item only renders when partOfSpeechId is not null.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    void onCreateInflectionTable(partOfSpeechId!).then(table => {
+    void onCreateInflectionTable().then(table => {
       if (table) {
         // It's not really necessary to add the table to the table menu, as
         // it will refresh fairly soon anyway (hopefully).
@@ -146,7 +116,7 @@ const TableList = React.memo((props: Props): JSX.Element => {
         });
       }
     });
-  }, [partOfSpeechId, addTable, onCreateInflectionTable]);
+  }, [addTable, onCreateInflectionTable]);
 
   const tables = field.value;
   return (
@@ -162,7 +132,6 @@ const TableList = React.memo((props: Props): JSX.Element => {
             index={index}
             totalCount={tables.length}
             allTableMap={inflectionTableMap}
-            partOfSpeechId={partOfSpeechId}
             stems={stems}
             moving={moving && CurrentMovingState.get(moving, index)}
             onMove={onMove}
@@ -177,30 +146,26 @@ const TableList = React.memo((props: Props): JSX.Element => {
         )}
       </S.TableList>
       <S.ListTools>
-        {partOfSpeechId !== null ? (
-          <MenuTrigger
-            menu={
-              <Menu>
-                {inflectionTableOptions}
-                {inflectionTableOptions.length > 0 && <Menu.Separator/>}
-                <Menu.Item
-                  label={l10n.getString('definition-new-table-menu')}
-                  onActivate={handleCreateInflectionTable}
-                />
-              </Menu>
-            }
-            openClass='force-active'
-          >
-            <Button>
-              <AddIcon/>
-              <span>
-                <Localized id='definition-add-table-button'/>
-              </span>
-            </Button>
-          </MenuTrigger>
-        ) : (
-          <Localized id='definition-tables-select-part-of-speech-helper'/>
-        )}
+        <MenuTrigger
+          menu={
+            <Menu>
+              {inflectionTableOptions}
+              {inflectionTableOptions.length > 0 && <Menu.Separator/>}
+              <Menu.Item
+                label={l10n.getString('definition-new-table-menu')}
+                onActivate={handleCreateInflectionTable}
+              />
+            </Menu>
+          }
+          openClass='force-active'
+        >
+          <Button>
+            <AddIcon/>
+            <span>
+              <Localized id='definition-add-table-button'/>
+            </span>
+          </Button>
+        </MenuTrigger>
       </S.ListTools>
     </Field>
   );

--- a/packages/app/src/renderer/forms/definition/table.tsx
+++ b/packages/app/src/renderer/forms/definition/table.tsx
@@ -14,7 +14,6 @@ import {DefinitionTable} from '@condict/table-editor';
 
 import {useNearestForm, useField, useFormValue} from '../../form';
 import {TableCaptionField, DefinitionTableField} from '../../form-fields';
-import {PartOfSpeechId} from '../../graphql';
 
 import upgradeLayout from './upgrade-layout';
 import {
@@ -29,7 +28,6 @@ export type Props = {
   index: number;
   totalCount: number;
   allTableMap: InflectionTableMap;
-  partOfSpeechId: PartOfSpeechId | null;
   stems: Map<string, string>;
   moving?: MovingState;
   onMove: (from: number, to: number) => void;
@@ -42,7 +40,6 @@ type TableStatus =
   | 'ok'
   | 'hasUpgrade'
   | 'needsUpgrade'
-  | 'wrongPartOfSpeech'
   | 'deleted';
 
 const StatusIcons = {
@@ -65,7 +62,6 @@ const Table = React.memo((props: Props): JSX.Element => {
     index,
     totalCount,
     allTableMap,
-    partOfSpeechId,
     stems,
     moving,
     onMove,
@@ -104,9 +100,7 @@ const Table = React.memo((props: Props): JSX.Element => {
   let status: TableStatus;
   if (!tableInfo) {
     status = 'deleted';
-  } else if (tableInfo.parent !== partOfSpeechId) {
-    status = 'wrongPartOfSpeech';
-  } else if (tableInfo.table.layout.id !== value.layoutId) {
+  } else if (tableInfo.layout.id !== value.layoutId) {
     status = value.id === null ? 'needsUpgrade' : 'hasUpgrade';
   } else {
     status = 'ok';
@@ -118,7 +112,7 @@ const Table = React.memo((props: Props): JSX.Element => {
       return;
     }
 
-    const nextLayout = tableInfo.table.layout;
+    const nextLayout = tableInfo.layout;
     const nextTable = upgradeLayout(field.value.table, nextLayout);
     field.update(draft => {
       draft.table = nextTable as Draft<DefinitionTable>;
@@ -128,17 +122,14 @@ const Table = React.memo((props: Props): JSX.Element => {
     });
   }, [tableInfo, canUpgrade]);
 
-  const hasError =
-    status === 'deleted' ||
-    status === 'wrongPartOfSpeech' ||
-    status === 'needsUpgrade';
+  const hasError = status === 'deleted' || status === 'needsUpgrade';
 
   return (
     <S.TableItem
       aria-label={l10n.getString('definition-inflection-table-title', {
         index: index + 1,
         total: totalCount,
-        name: tableInfo?.table.name ?? '',
+        name: tableInfo?.name ?? '',
       })}
       style={moving && {
         top: moving.offset,
@@ -152,7 +143,7 @@ const Table = React.memo((props: Props): JSX.Element => {
       <TableToolbar
         index={index}
         isLast={index === totalCount - 1}
-        tableName={tableInfo?.table.name}
+        tableName={tableInfo?.name}
         onMove={onMove}
         onRemove={onRemove}
         onDragStart={onDragStart}

--- a/packages/app/src/renderer/forms/definition/types.ts
+++ b/packages/app/src/renderer/forms/definition/types.ts
@@ -53,7 +53,6 @@ export interface DefinitionTableFormData extends DefinitionTableData {
 export interface PartOfSpeechFields {
   readonly id: PartOfSpeechId;
   readonly name: string;
-  readonly inflectionTables: readonly InflectionTableFields[];
 }
 
 export interface InflectionTableFields {
@@ -68,12 +67,7 @@ export interface InflectionTableLayoutFields {
   readonly rows: DefinitionTableRowJson[];
 }
 
-export interface InflectionTableInfo {
-  readonly parent: PartOfSpeechId;
-  readonly table: InflectionTableFields;
-}
-
-export type InflectionTableMap = Map<InflectionTableId, InflectionTableInfo>;
+export type InflectionTableMap = Map<InflectionTableId, InflectionTableFields>;
 
 // Used when moving
 export interface MovingState {

--- a/packages/app/src/renderer/forms/inflection-table/index.tsx
+++ b/packages/app/src/renderer/forms/inflection-table/index.tsx
@@ -6,7 +6,7 @@ import {InflectionTable} from '@condict/table-editor';
 
 import {FormProvider, useForm} from '../../form';
 import {TextField, InflectionTableField, FormButtons} from '../../form-fields';
-import {InflectionTableId, LanguageId, PartOfSpeechId} from '../../graphql';
+import {InflectionTableId, LanguageId} from '../../graphql';
 import {useExecute} from '../../data';
 
 import {notEmpty, nameNotTaken} from '../validators';
@@ -16,7 +16,6 @@ import {CheckNameQuery} from './query';
 
 export type Props = {
   languageId: LanguageId;
-  partOfSpeechId: PartOfSpeechId;
   initialData?: InflectionTableData;
   submitError?: ReactNode;
   firstFieldRef?: RefObject<HTMLElement>;
@@ -58,7 +57,6 @@ const EmptyData: InflectionTableData = {
 export const InflectionTableForm = (props: Props): JSX.Element => {
   const {
     languageId,
-    partOfSpeechId,
     initialData = EmptyData,
     submitError,
     firstFieldRef,
@@ -87,8 +85,8 @@ export const InflectionTableForm = (props: Props): JSX.Element => {
             notEmpty,
             nameNotTaken(
               initialData.id,
-              name => execute(CheckNameQuery, {pos: partOfSpeechId, name}),
-              data => data.partOfSpeech?.inflectionTableByName?.id ?? null
+              name => execute(CheckNameQuery, {lang: languageId, name}),
+              data => data.language?.inflectionTableByName?.id ?? null
             ),
           ]}
           errorMessages={{
@@ -101,7 +99,6 @@ export const InflectionTableForm = (props: Props): JSX.Element => {
           name='layout'
           label={<Localized id='inflection-table-layout-label'/>}
           languageId={languageId}
-          partOfSpeechId={partOfSpeechId}
           inflectionTableId={initialData.id}
         />
         <FormButtons submitError={submitError} onCancel={onCancel}/>

--- a/packages/app/src/renderer/forms/inflection-table/query.graphql
+++ b/packages/app/src/renderer/forms/inflection-table/query.graphql
@@ -1,5 +1,5 @@
-query CheckNameQuery($pos: PartOfSpeechId!, $name: String!) {
-  partOfSpeech(id: $pos) {
+query CheckNameQuery($lang: LanguageId!, $name: String!) {
+  language(id: $lang) {
     inflectionTableByName(name: $name) {
       id
     }

--- a/packages/app/src/renderer/forms/inflection-table/query.ts
+++ b/packages/app/src/renderer/forms/inflection-table/query.ts
@@ -4,15 +4,15 @@
 
 import {
   Query,
-  PartOfSpeechId,
+  LanguageId,
   InflectionTableId
 } from "../../graphql";
 
-export const CheckNameQuery = "query CheckNameQuery($pos:PartOfSpeechId!,$name:String!){partOfSpeech(id:$pos){inflectionTableByName(name:$name){id}}}" as Query<{
-  pos: PartOfSpeechId;
+export const CheckNameQuery = "query CheckNameQuery($lang:LanguageId!,$name:String!){language(id:$lang){inflectionTableByName(name:$name){id}}}" as Query<{
+  lang: LanguageId;
   name: string;
 }, {
-  partOfSpeech: {
+  language: {
     inflectionTableByName: {
       id: InflectionTableId;
     } | null;

--- a/packages/app/src/renderer/graphql.ts
+++ b/packages/app/src/renderer/graphql.ts
@@ -80,14 +80,14 @@ export type LemmaId = IdOf<'Lemma'>;
 export type DefinitionId = IdOf<'Definition'>;
 
 /**
- * Represents a part of speech ID.
- */
-export type PartOfSpeechId = IdOf<'PartOfSpeech'>;
-
-/**
  * Represents an inflection table ID.
  */
 export type InflectionTableId = IdOf<'InflectionTable'>;
+
+/**
+ * Represents a part of speech ID.
+ */
+export type PartOfSpeechId = IdOf<'PartOfSpeech'>;
 
 /**
  * Represents an inflection table layout ID.
@@ -293,9 +293,9 @@ export type EditPartOfSpeechInput = {
  */
 export type NewInflectionTableInput = {
   /**
-   * The part of speech that the inflection table will be added to.
+   * The language that the inflection table will be added to.
    */
-  partOfSpeechId: PartOfSpeechId;
+  languageId: LanguageId;
   /**
    * The name of the inflection table.
    */
@@ -381,7 +381,7 @@ export type InflectedFormInput = {
 
 /**
  * Input type for editing an existing inflection table. It is not possible to move
- * an inflection table to another part of speech.
+ * an inflection table to another language.
  */
 export type EditInflectionTableInput = {
   /**
@@ -498,11 +498,6 @@ export type EditDefinitionInput = {
   term?: string | null | undefined;
   /**
    * If set, updates the part of speech.
-   * 
-   * If this field is set to a value other than the definition's current part of
-   * speech, and `inflectionTables` is _not_ set, then the definition's inflection
-   * tables will all be deleted. In other words, changing the part of speech will
-   * delete inflection tables unless you specify new ones.
    */
   partOfSpeechId?: PartOfSpeechId | null | undefined;
   /**

--- a/packages/app/src/renderer/pages/home/query.graphql
+++ b/packages/app/src/renderer/pages/home/query.graphql
@@ -47,11 +47,7 @@ query($tagsPage: Int!) {
       ...on InflectionTable {
         inflectionTableId: id
         name
-        partOfSpeech {
-          id
-          name
-          language { id, name }
-        }
+        language { id, name }
       }
     }
   }

--- a/packages/app/src/renderer/pages/home/query.ts
+++ b/packages/app/src/renderer/pages/home/query.ts
@@ -14,7 +14,7 @@ import {
   InflectionTableId
 } from "../../graphql";
 
-export default "query($tagsPage:Int!){languages{id,name,description{...RichTextBlockFragment}statistics{lemmaCount,definitionCount,partOfSpeechCount,tagCount}}tags(page:{page:$tagsPage,perPage:100}){page{page,hasNext}nodes{id,name}}recentChanges(page:{page:0,perPage:8}){nodes{__typename,timeCreated,timeUpdated...on Language{languageId:id,name}...on Definition{definitionId:id,term,language{id,name}}...on PartOfSpeech{partOfSpeechId:id,name,language{id,name}}...on InflectionTable{inflectionTableId:id,name,partOfSpeech{id,name,language{id,name}}}}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
+export default "query($tagsPage:Int!){languages{id,name,description{...RichTextBlockFragment}statistics{lemmaCount,definitionCount,partOfSpeechCount,tagCount}}tags(page:{page:$tagsPage,perPage:100}){page{page,hasNext}nodes{id,name}}recentChanges(page:{page:0,perPage:8}){nodes{__typename,timeCreated,timeUpdated...on Language{languageId:id,name}...on Definition{definitionId:id,term,language{id,name}}...on PartOfSpeech{partOfSpeechId:id,name,language{id,name}}...on InflectionTable{inflectionTableId:id,name,language{id,name}}}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
   tagsPage: number;
 }, {
   languages: {
@@ -133,13 +133,9 @@ export default "query($tagsPage:Int!){languages{id,name,description{...RichTextB
       timeUpdated: UtcInstant;
       inflectionTableId: InflectionTableId;
       name: string;
-      partOfSpeech: {
-        id: PartOfSpeechId;
+      language: {
+        id: LanguageId;
         name: string;
-        language: {
-          id: LanguageId;
-          name: string;
-        };
       };
     })[];
   } | null;

--- a/packages/app/src/renderer/pages/home/recent-change-card.tsx
+++ b/packages/app/src/renderer/pages/home/recent-change-card.tsx
@@ -80,19 +80,14 @@ const RecentChangeCard = ({item}: Props): JSX.Element => {
       name = item.name;
       iconType = 'inflectionTable';
 
-      const pos = item.partOfSpeech;
-      const lang = pos.language;
+      const lang = item.language;
       const langPage = LanguagePage(lang.id, lang.name);
-      const posPage = PartOfSpeechPage(pos.id, pos.name, langPage);
       page = InflectionTablePage(item.inflectionTableId, name, langPage);
       description =
         <Localized
           id='home-recent-inflection-table-description'
-          vars={{partOfSpeech: pos.name, language: lang.name}}
-          elems={{
-            'pos-link': <Link to={posPage}/>,
-            'lang-link': <Link to={langPage}/>,
-          }}
+          vars={{language: lang.name}}
+          elems={{'lang-link': <Link to={langPage}/>}}
         >
           <></>
         </Localized>;

--- a/packages/app/src/renderer/pages/inflection-table/index.tsx
+++ b/packages/app/src/renderer/pages/inflection-table/index.tsx
@@ -8,7 +8,6 @@ import {InflectionTableId, LanguageId} from '../../graphql';
 import {useOpenPanel} from '../../navigation';
 import {
   LanguagePage,
-  PartOfSpeechPage,
   InflectionTablePage as InflectionTableTarget,
 } from '../../page';
 import {
@@ -71,10 +70,8 @@ const InflectionTablePage = (props: Props): JSX.Element => {
           );
         }
 
-        const pos = table.partOfSpeech;
-        const lang = pos.language;
+        const lang = table.language;
         const langPage = LanguagePage(lang.id, lang.name);
-        const posPage = PartOfSpeechPage(pos.id, pos.name, langPage);
         return <>
           <MainHeader>
             <Selectable as='h1'>{table.name}</Selectable>
@@ -85,11 +82,8 @@ const InflectionTablePage = (props: Props): JSX.Element => {
           <Subheader>
             <Localized
               id='inflection-table-subheading'
-              vars={{partOfSpeech: pos.name, language: lang.name}}
-              elems={{
-                'pos-link': <Link to={posPage}/>,
-                'lang-link': <Link to={langPage}/>,
-              }}
+              vars={{language: lang.name}}
+              elems={{'lang-link': <Link to={langPage}/>}}
             >
               <span></span>
             </Localized>

--- a/packages/app/src/renderer/pages/inflection-table/query.graphql
+++ b/packages/app/src/renderer/pages/inflection-table/query.graphql
@@ -5,14 +5,9 @@ query($id: InflectionTableId!) {
     timeCreated
     timeUpdated
 
-    partOfSpeech {
+    language {
       id
       name
-
-      language {
-        id
-        name
-      }
     }
 
     layout {

--- a/packages/app/src/renderer/pages/inflection-table/query.ts
+++ b/packages/app/src/renderer/pages/inflection-table/query.ts
@@ -6,27 +6,23 @@ import {
   Query,
   InflectionTableId,
   UtcInstant,
-  PartOfSpeechId,
   LanguageId,
   DefinitionId,
   BlockKind,
-  LemmaId
+  LemmaId,
+  PartOfSpeechId
 } from "../../graphql";
 
-export default "query($id:InflectionTableId!){inflectionTable(id:$id){name,timeCreated,timeUpdated,partOfSpeech{id,name,language{id,name}}layout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}oldLayouts{page{totalCount}}usedBy:usedByDefinitions(layout:ALL_LAYOUTS){page{totalCount,hasNext}nodes{definition{...DefinitionSummaryFragment}hasOldLayouts}}oldUsedBy:usedByDefinitions(layout:OLD_LAYOUTS){page{totalCount,hasNext}nodes{definition{...DefinitionSummaryFragment}}}}}fragment DefinitionSummaryFragment on Definition{id,term,partOfSpeech{name}description{...RichTextBlockFragment}timeCreated,timeUpdated}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
+export default "query($id:InflectionTableId!){inflectionTable(id:$id){name,timeCreated,timeUpdated,language{id,name}layout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}oldLayouts{page{totalCount}}usedBy:usedByDefinitions(layout:ALL_LAYOUTS){page{totalCount,hasNext}nodes{definition{...DefinitionSummaryFragment}hasOldLayouts}}oldUsedBy:usedByDefinitions(layout:OLD_LAYOUTS){page{totalCount,hasNext}nodes{definition{...DefinitionSummaryFragment}}}}}fragment DefinitionSummaryFragment on Definition{id,term,partOfSpeech{name}description{...RichTextBlockFragment}timeCreated,timeUpdated}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
   id: InflectionTableId;
 }, {
   inflectionTable: {
     name: string;
     timeCreated: UtcInstant;
     timeUpdated: UtcInstant;
-    partOfSpeech: {
-      id: PartOfSpeechId;
+    language: {
+      id: LanguageId;
       name: string;
-      language: {
-        id: LanguageId;
-        name: string;
-      };
     };
     layout: {
       rows: {

--- a/packages/app/src/renderer/pages/language/index.tsx
+++ b/packages/app/src/renderer/pages/language/index.tsx
@@ -7,6 +7,7 @@ import {
   LanguagePage as LanguageTarget,
   DefinitionPage,
   PartOfSpeechPage,
+  InflectionTablePage,
   SearchPage,
 } from '../../page';
 import {useNavigateTo, useOpenPanel} from '../../navigation';
@@ -28,6 +29,7 @@ import {
   editLanguagePanel,
   addDefinitionPanel,
   addPartOfSpeechPanel,
+  addInflectionTablePanel,
 } from '../../panels';
 
 import usePageData from '../page-data';
@@ -37,6 +39,7 @@ import LanguageQuery from './query';
 import LanguageSearch from './language-search';
 import LemmaAndDefinitionList from './lemma-and-definition-list';
 import PartOfSpeechList from './part-of-speech-list';
+import InflectionTableList from './inflection-table-list';
 
 export type Props = {
   id: LanguageId;
@@ -86,6 +89,21 @@ const LanguagePage = (props: Props): JSX.Element => {
         const lang = pos.language;
         const langPage = LanguageTarget(lang.id, lang.name);
         navigateTo(PartOfSpeechPage(pos.id, pos.name, langPage), {
+          openInNewTab: true,
+          openInBackground: false,
+        });
+      }
+    });
+  }, [id]);
+
+  const handleAddTable = useCallback(() => {
+    void openPanel(addInflectionTablePanel({
+      languageId: id,
+    })).then(table => {
+      if (table) {
+        const lang = table.language;
+        const langPage = LanguageTarget(lang.id, lang.name);
+        navigateTo(InflectionTablePage(table.id, table.name, langPage), {
           openInNewTab: true,
           openInBackground: false,
         });
@@ -148,20 +166,22 @@ const LanguagePage = (props: Props): JSX.Element => {
             />
           </>}
 
-          <h2 id={`${htmlId}-pos-title`}>
-            <Localized id='language-parts-of-speech-heading'/>
-          </h2>
           <PartOfSpeechList
-            aria-labelledby={`${htmlId}-pos-title`}
             parent={langPage}
             partsOfSpeech={language.partsOfSpeech}
             onAddPartOfSpeech={handleAddPartOfSpeech}
           />
 
-          <h2 id={`${htmlId}-tags-title`}>
-            <Localized id='language-tags-heading'/>
-          </h2>
-          <section aria-labelledby={`${htmlId}-tags-title`}>
+          <InflectionTableList
+            parent={langPage}
+            tables={language.inflectionTables}
+            onAddTable={handleAddTable}
+          />
+
+          <section>
+            <h2>
+              <Localized id='language-tags-heading'/>
+            </h2>
             {language.tags.nodes.length > 0 ? (
               <TagList
                 tags={language.tags.nodes}

--- a/packages/app/src/renderer/pages/language/inflection-table-list.tsx
+++ b/packages/app/src/renderer/pages/language/inflection-table-list.tsx
@@ -7,25 +7,25 @@ import {InflectionTablePage, LanguagePage} from '../../page';
 import {LinkCard, FullRow, Secondary, ResourceTime} from '../../ui';
 import {OperationResult} from '../../graphql';
 
-import PartOfSpeechQuery from './query';
+import LanguageQuery from './query';
 import * as S from './styles';
 
 export type Props = {
-  language: LanguagePage;
+  parent: LanguagePage;
   tables: InflectionTables;
   onAddTable: () => void;
 };
 
 type InflectionTables = NonNullable<
-  OperationResult<typeof PartOfSpeechQuery>['partOfSpeech']
+  OperationResult<typeof LanguageQuery>['language']
 >['inflectionTables'];
 
 const InflectionTableList = (props: Props): JSX.Element => {
-  const {language, tables, onAddTable} = props;
+  const {parent, tables, onAddTable} = props;
   return (
     <section>
       <h2>
-        <Localized id='part-of-speech-tables-heading'/>
+        <Localized id='language-tables-heading'/>
       </h2>
 
       {tables.length > 0 ? (
@@ -33,12 +33,12 @@ const InflectionTableList = (props: Props): JSX.Element => {
           {tables.map(table =>
             <LinkCard
               key={table.id}
-              to={InflectionTablePage(table.id, table.name, language)}
+              to={InflectionTablePage(table.id, table.name, parent)}
               title={table.name}
             >
               <p>
                 <Localized
-                  id='part-of-speech-table-used-by-definitions'
+                  id='language-table-used-by-definitions'
                   vars={{
                     definitionCount: table.usedByDefinitions.page.totalCount,
                   }}
@@ -54,23 +54,23 @@ const InflectionTableList = (props: Props): JSX.Element => {
             </LinkCard>
           )}
           <FullRow>
-            <Button intent='bold' onClick={onAddTable}>
+            <Button onClick={onAddTable}>
               <AddIcon/>
               <span>
-                <Localized id='part-of-speech-add-table-button'/>
+                <Localized id='language-add-table-button'/>
               </span>
             </Button>
           </FullRow>
         </S.InflectionTableList>
       ) : <>
         <BodyText as='p'>
-          <Localized id='part-of-speech-no-tables-description'/>
+          <Localized id='language-no-tables-description'/>
         </BodyText>
         <p>
-          <Button intent='accent' onClick={onAddTable}>
+          <Button intent='bold' onClick={onAddTable}>
             <AddIcon/>
             <span>
-              <Localized id='part-of-speech-add-table-button'/>
+              <Localized id='language-add-table-button'/>
             </span>
           </Button>
         </p>

--- a/packages/app/src/renderer/pages/language/lemma-and-definition-list.tsx
+++ b/packages/app/src/renderer/pages/language/lemma-and-definition-list.tsx
@@ -38,8 +38,8 @@ const LemmaAndDefinitionList = (props: Props): JSX.Element => {
 
   if (lemmaCount === 0) {
     return (
-      <section aria-labelledby={`${htmlId}-lemmas-title`}>
-        <SROnly as='h2' id={`${htmlId}-lemmas-title`}>
+      <section>
+        <SROnly as='h2'>
           <Localized id='language-words-in-language-heading'/>
         </SROnly>
 
@@ -61,8 +61,8 @@ const LemmaAndDefinitionList = (props: Props): JSX.Element => {
   }
 
   return (
-    <section aria-labelledby={`${htmlId}-lemmas-title`}>
-      <SROnly as='h2' id={`${htmlId}-lemmas-title`}>
+    <section>
+      <SROnly as='h2'>
         <Localized id='language-words-in-language-heading'/>
       </SROnly>
 

--- a/packages/app/src/renderer/pages/language/part-of-speech-list.tsx
+++ b/packages/app/src/renderer/pages/language/part-of-speech-list.tsx
@@ -11,7 +11,6 @@ import LanguageQuery from './query';
 import * as S from './styles';
 
 export type Props = {
-  'aria-labelledby': string;
   parent: LanguagePage;
   partsOfSpeech: PartsOfSpeech;
   onAddPartOfSpeech: () => void;
@@ -23,13 +22,16 @@ type PartsOfSpeech = NonNullable<
 
 const PartOfSpeechList = (props: Props): JSX.Element => {
   const {
-    'aria-labelledby': ariaLabelledby,
     parent,
     partsOfSpeech,
     onAddPartOfSpeech,
   } = props;
   return (
-    <section aria-labelledby={ariaLabelledby}>
+    <section>
+      <h2>
+        <Localized id='language-parts-of-speech-heading'/>
+      </h2>
+
       {partsOfSpeech.length > 0 ? (
         <S.PartOfSpeechList>
           {partsOfSpeech.map(pos =>
@@ -38,12 +40,6 @@ const PartOfSpeechList = (props: Props): JSX.Element => {
               to={PartOfSpeechPage(pos.id, pos.name, parent)}
               title={<h3>{pos.name}</h3>}
             >
-              <p>
-                <Localized
-                  id='language-part-of-speech-tables'
-                  vars={{tableCount: pos.statistics.inflectionTableCount}}
-                />
-              </p>
               <p>
                 <Localized
                   id='language-part-of-speech-used-by-definitions'

--- a/packages/app/src/renderer/pages/language/query.graphql
+++ b/packages/app/src/renderer/pages/language/query.graphql
@@ -17,6 +17,8 @@ query($id: LanguageId!) {
       nodes {
         id
         term
+        timeCreated
+        timeUpdated
 
         partOfSpeech {
           name
@@ -25,23 +27,31 @@ query($id: LanguageId!) {
         description {
           ...RichTextBlockFragment
         }
-
-        timeCreated
-        timeUpdated
       }
     }
 
     partsOfSpeech {
       id
       name
-
-      statistics {
-        inflectionTableCount
-        definitionCount
-      }
-
       timeCreated
       timeUpdated
+
+      statistics {
+        definitionCount
+      }
+    }
+
+    inflectionTables {
+      id
+      name
+      timeCreated
+      timeUpdated
+
+      usedByDefinitions {
+        page {
+          totalCount
+        }
+      }
     }
 
     tags(page: {page: 0, perPage: 100}) {

--- a/packages/app/src/renderer/pages/language/query.ts
+++ b/packages/app/src/renderer/pages/language/query.ts
@@ -10,10 +10,11 @@ import {
   DefinitionId,
   PartOfSpeechId,
   UtcInstant,
+  InflectionTableId,
   TagId
 } from "../../graphql";
 
-export default "query($id:LanguageId!){language(id:$id){name,description{...RichTextBlockFragment}lemmaCount,firstLemma{term}lastLemma{term}timeCreated,timeUpdated,recentDefinitions(page:{page:0,perPage:5}){nodes{id,term,partOfSpeech{name}description{...RichTextBlockFragment}timeCreated,timeUpdated}}partsOfSpeech{id,name,statistics{inflectionTableCount,definitionCount}timeCreated,timeUpdated}tags(page:{page:0,perPage:100}){page{page,hasNext}nodes{id,name}}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
+export default "query($id:LanguageId!){language(id:$id){name,description{...RichTextBlockFragment}lemmaCount,firstLemma{term}lastLemma{term}timeCreated,timeUpdated,recentDefinitions(page:{page:0,perPage:5}){nodes{id,term,timeCreated,timeUpdated,partOfSpeech{name}description{...RichTextBlockFragment}}}partsOfSpeech{id,name,timeCreated,timeUpdated,statistics{definitionCount}}inflectionTables{id,name,timeCreated,timeUpdated,usedByDefinitions{page{totalCount}}}tags(page:{page:0,perPage:100}){page{page,hasNext}nodes{id,name}}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
   id: LanguageId;
 }, {
   language: {
@@ -94,6 +95,8 @@ export default "query($id:LanguageId!){language(id:$id){name,description{...Rich
       nodes: {
         id: DefinitionId;
         term: string;
+        timeCreated: UtcInstant;
+        timeUpdated: UtcInstant;
         partOfSpeech: {
           name: string;
         };
@@ -160,19 +163,27 @@ export default "query($id:LanguageId!){language(id:$id){name,description{...Rich
             }[];
           })[];
         }[];
-        timeCreated: UtcInstant;
-        timeUpdated: UtcInstant;
       }[];
     };
     partsOfSpeech: {
       id: PartOfSpeechId;
       name: string;
-      statistics: {
-        inflectionTableCount: number;
-        definitionCount: number;
-      };
       timeCreated: UtcInstant;
       timeUpdated: UtcInstant;
+      statistics: {
+        definitionCount: number;
+      };
+    }[];
+    inflectionTables: {
+      id: InflectionTableId;
+      name: string;
+      timeCreated: UtcInstant;
+      timeUpdated: UtcInstant;
+      usedByDefinitions: {
+        page: {
+          totalCount: number;
+        };
+      };
     }[];
     tags: {
       page: {

--- a/packages/app/src/renderer/pages/language/styles.ts
+++ b/packages/app/src/renderer/pages/language/styles.ts
@@ -31,3 +31,7 @@ export const NoLemmas = styled(NonIdealState)`
 export const PartOfSpeechList = styled(CardGrid)`
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
 `;
+
+export const InflectionTableList = styled(CardGrid)`
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+`;

--- a/packages/app/src/renderer/pages/part-of-speech/index.tsx
+++ b/packages/app/src/renderer/pages/part-of-speech/index.tsx
@@ -1,11 +1,10 @@
 import {useCallback} from 'react';
 import {Localized} from '@fluent/react';
 
-import {useNavigateTo, useOpenPanel} from '../../navigation';
+import {useOpenPanel} from '../../navigation';
 import {
   LanguagePage,
   PartOfSpeechPage as PartOfSpeechTarget,
-  InflectionTablePage,
 } from '../../page';
 import {
   FlowContent,
@@ -19,12 +18,11 @@ import {
   renderData,
 } from '../../ui';
 import {PartOfSpeechId, LanguageId} from '../../graphql';
-import {editPartOfSpeechPanel, addInflectionTablePanel} from '../../panels';
+import {editPartOfSpeechPanel} from '../../panels';
 
 import usePageData from '../page-data';
 import {PageProps} from '../types';
 
-import InflectionTableList from './inflection-table-list';
 import DefinitionList from './definition-list';
 import PartOfSpeechQuery from './query';
 
@@ -42,7 +40,6 @@ const PartOfSpeechPage = (props: Props): JSX.Element => {
     pageTitle: data => data.partOfSpeech?.name,
     reloadOn: event => (
       event.type === 'partOfSpeech' && event.id === id ||
-      event.type === 'inflectionTable' && event.partOfSpeechId === id ||
       event.type === 'definition' && (
         event.partOfSpeechId === id ||
         event.action === 'update' && event.prevPartOfSpeechId === id
@@ -55,23 +52,6 @@ const PartOfSpeechPage = (props: Props): JSX.Element => {
   const openPanel = useOpenPanel();
   const handleEditPartOfSpeech = useCallback(() => {
     void openPanel(editPartOfSpeechPanel(id));
-  }, [id]);
-
-  const navigateTo = useNavigateTo();
-  const handleAddTable = useCallback(() => {
-    void openPanel(addInflectionTablePanel({
-      languageId,
-      partOfSpeechId: id,
-    })).then(table => {
-      if (table) {
-        const lang = table.partOfSpeech.language;
-        const langPage = LanguagePage(lang.id, lang.name);
-        navigateTo(InflectionTablePage(table.id, table.name, langPage), {
-          openInNewTab: true,
-          openInBackground: false,
-        });
-      }
-    });
   }, [id]);
 
   return (
@@ -111,12 +91,6 @@ const PartOfSpeechPage = (props: Props): JSX.Element => {
               />
             </ResourceMeta>
           </Subheader>
-
-          <InflectionTableList
-            language={langPage}
-            tables={pos.inflectionTables}
-            onAddTable={handleAddTable}
-          />
 
           <DefinitionList
             definitions={usedBy}

--- a/packages/app/src/renderer/pages/part-of-speech/query.graphql
+++ b/packages/app/src/renderer/pages/part-of-speech/query.graphql
@@ -10,19 +10,6 @@ query($id: PartOfSpeechId!) {
       name
     }
 
-    inflectionTables {
-      id
-      name
-      timeCreated
-      timeUpdated
-
-      usedByDefinitions {
-        page {
-          totalCount
-        }
-      }
-    }
-
     usedByDefinitions(page: {page: 0, perPage: 5}) {
       page {
         totalCount

--- a/packages/app/src/renderer/pages/part-of-speech/query.ts
+++ b/packages/app/src/renderer/pages/part-of-speech/query.ts
@@ -7,13 +7,12 @@ import {
   PartOfSpeechId,
   UtcInstant,
   LanguageId,
-  InflectionTableId,
   DefinitionId,
   BlockKind,
   LemmaId
 } from "../../graphql";
 
-export default "query($id:PartOfSpeechId!){partOfSpeech(id:$id){name,timeCreated,timeUpdated,language{id,name}inflectionTables{id,name,timeCreated,timeUpdated,usedByDefinitions{page{totalCount}}}usedByDefinitions(page:{page:0,perPage:5}){page{totalCount,hasNext}nodes{id,term,description{...RichTextBlockFragment}timeCreated,timeUpdated}}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
+export default "query($id:PartOfSpeechId!){partOfSpeech(id:$id){name,timeCreated,timeUpdated,language{id,name}usedByDefinitions(page:{page:0,perPage:5}){page{totalCount,hasNext}nodes{id,term,description{...RichTextBlockFragment}timeCreated,timeUpdated}}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}" as Query<{
   id: PartOfSpeechId;
 }, {
   partOfSpeech: {
@@ -24,17 +23,6 @@ export default "query($id:PartOfSpeechId!){partOfSpeech(id:$id){name,timeCreated
       id: LanguageId;
       name: string;
     };
-    inflectionTables: {
-      id: InflectionTableId;
-      name: string;
-      timeCreated: UtcInstant;
-      timeUpdated: UtcInstant;
-      usedByDefinitions: {
-        page: {
-          totalCount: number;
-        };
-      };
-    }[];
     usedByDefinitions: {
       page: {
         totalCount: number;

--- a/packages/app/src/renderer/pages/part-of-speech/styles.ts
+++ b/packages/app/src/renderer/pages/part-of-speech/styles.ts
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-
-import {CardGrid} from '../../ui';
-
-export const InflectionTableList = styled(CardGrid)`
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-`;

--- a/packages/app/src/renderer/panels/add-definition.tsx
+++ b/packages/app/src/renderer/panels/add-definition.tsx
@@ -1,4 +1,4 @@
-import {useState, useMemo, useCallback, useRef} from 'react';
+import {useState, useCallback, useRef} from 'react';
 import {Localized} from '@fluent/react';
 
 import {
@@ -9,7 +9,7 @@ import {
 import {FlowContent, MainHeader, BlockFields, renderData} from '../ui';
 import {PanelParams, PanelProps, useOpenPanel} from '../navigation';
 import {DefinitionData, DefinitionForm} from '../forms';
-import {DefinitionId, LanguageId, PartOfSpeechId} from '../graphql';
+import {DefinitionId, LanguageId} from '../graphql';
 import {useData, useExecute} from '../data';
 import {useRefocusOnData} from '../hooks';
 
@@ -92,25 +92,15 @@ const AddDefinitionPanel = (props: Props): JSX.Element => {
     preventScroll: entering,
   });
 
-  const initialPartsOfSpeech = useMemo(() => {
-    if (data.state === 'loading' || !data.result.data?.language) {
-      return [];
-    }
-    return data.result.data.language.partsOfSpeech;
-  }, [data]);
-
   const openPanel = useOpenPanel();
 
   const createPartOfSpeech = useCallback(() => {
     return openPanel(addPartOfSpeechPanel(languageId));
   }, [languageId, openPanel]);
 
-  const createInflectionTable = useCallback((
-    partOfSpeechId: PartOfSpeechId
-  ) => {
+  const createInflectionTable = useCallback(() => {
     return openPanel(addInflectionTablePanel({
       languageId,
-      partOfSpeechId,
     }));
   }, [languageId, openPanel]);
 
@@ -121,10 +111,11 @@ const AddDefinitionPanel = (props: Props): JSX.Element => {
           <Localized id='language-define-word-title'/>
         </h1>
       </MainHeader>
-      {renderData(data, () =>
+      {renderData(data, ({language}) =>
         <DefinitionForm
           languageId={languageId}
-          initialPartsOfSpeech={initialPartsOfSpeech}
+          initialPartsOfSpeech={language?.partsOfSpeech ?? []}
+          initialInflectionTables={language?.inflectionTables ?? []}
           submitError={
             submitError && <Localized id='inflection-table-save-error'/>
           }

--- a/packages/app/src/renderer/panels/add-inflection-table.tsx
+++ b/packages/app/src/renderer/panels/add-inflection-table.tsx
@@ -12,7 +12,6 @@ import {
   InflectionTableLayoutId,
   InflectionTableRowInput,
   LanguageId,
-  PartOfSpeechId,
 } from '../graphql';
 
 import {AddInflectionTableMut} from './query';
@@ -25,23 +24,18 @@ export interface NewInflectionTable {
     stems: string[];
     rows: InflectionTableJson;
   };
-  partOfSpeech: {
-    id: PartOfSpeechId;
+  language: {
+    id: LanguageId;
     name: string;
-    language: {
-      id: LanguageId;
-      name: string;
-    };
   };
 }
 
 type Props = {
   languageId: LanguageId;
-  partOfSpeechId: PartOfSpeechId;
 } & PanelProps<NewInflectionTable | null>;
 
 const AddInflectionTablePanel = (props: Props) => {
-  const {languageId, partOfSpeechId, updatePanel, titleId, onResolve} = props;
+  const {languageId, updatePanel, titleId, onResolve} = props;
 
   const execute = useExecute();
 
@@ -52,7 +46,7 @@ const AddInflectionTablePanel = (props: Props) => {
 
     const res = await execute(AddInflectionTableMut, {
       data: {
-        partOfSpeechId,
+        languageId,
         name: formData.name,
         layout:
           InflectionTable.export(formData.layout) as
@@ -70,7 +64,7 @@ const AddInflectionTablePanel = (props: Props) => {
     // If there were no errors, we should have a part of speech.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     onResolve(res.data!.addInflectionTable);
-  }, [partOfSpeechId, onResolve]);
+  }, [onResolve]);
 
   return (
     <FlowContent>
@@ -79,7 +73,6 @@ const AddInflectionTablePanel = (props: Props) => {
       </h1>
       <InflectionTableForm
         languageId={languageId}
-        partOfSpeechId={partOfSpeechId}
         submitError={submitError && <Localized id='inflection-table-save-error'/>}
         onSubmit={onSubmit}
         onCancel={() => onResolve(null)}
@@ -91,7 +84,6 @@ const AddInflectionTablePanel = (props: Props) => {
 
 export const addInflectionTablePanel = (ids: {
   languageId: LanguageId;
-  partOfSpeechId: PartOfSpeechId;
 }): PanelParams<NewInflectionTable | null> => ({
   // eslint-disable-next-line react/display-name
   render: props => <AddInflectionTablePanel {...props} {...ids}/>,

--- a/packages/app/src/renderer/panels/edit-definition.tsx
+++ b/packages/app/src/renderer/panels/edit-definition.tsx
@@ -14,7 +14,7 @@ import {DefinitionTable} from '@condict/table-editor';
 import {FlowContent, MainHeader} from '../ui';
 import {PanelParams, PanelProps, useOpenPanel} from '../navigation';
 import {DefinitionData, DefinitionForm} from '../forms';
-import {DefinitionId, LanguageId, LemmaId, PartOfSpeechId} from '../graphql';
+import {DefinitionId, LanguageId, LemmaId} from '../graphql';
 import {useData, useExecute} from '../data';
 import {useRefocusOnData} from '../hooks';
 
@@ -116,15 +116,12 @@ const EditDefinitionPanel = (props: Props): JSX.Element => {
     return openPanel(addPartOfSpeechPanel(languageId!));
   }, [languageId, openPanel]);
 
-  const createInflectionTable = useCallback((
-    partOfSpeechId: PartOfSpeechId
-  ) => {
+  const createInflectionTable = useCallback(() => {
     return openPanel(addInflectionTablePanel({
       // It should not be possible to trigger this panel before the language is
       // available.
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       languageId: languageId!,
-      partOfSpeechId,
     }));
   }, [languageId, openPanel]);
 
@@ -196,6 +193,7 @@ const EditDefinitionPanel = (props: Props): JSX.Element => {
             initialData={initialData}
             languageId={def.language.id}
             initialPartsOfSpeech={def.language.partsOfSpeech}
+            initialInflectionTables={def.language.inflectionTables}
             submitError={
               submitError && <Localized id='definition-save-error'/>
             }

--- a/packages/app/src/renderer/panels/edit-inflection-table.tsx
+++ b/packages/app/src/renderer/panels/edit-inflection-table.tsx
@@ -120,8 +120,7 @@ const EditInflectionTablePanel = (props: Props) => {
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               layout: layout!,
             }}
-            languageId={table.partOfSpeech.language.id}
-            partOfSpeechId={table.partOfSpeech.id}
+            languageId={table.language.id}
             submitError={
               submitError && <Localized id='inflection-table-save-error'/>
             }

--- a/packages/app/src/renderer/panels/query.graphql
+++ b/packages/app/src/renderer/panels/query.graphql
@@ -92,13 +92,9 @@ mutation AddInflectionTableMut($data: NewInflectionTableInput!) {
       stems
       ...InflectionTableFragment
     }
-    partOfSpeech {
+    language {
       id
       name
-      language {
-        id
-        name
-      }
     }
   }
 }
@@ -113,12 +109,8 @@ query EditInflectionTableQuery($id: InflectionTableId!) {
       ...InflectionTableFragment
     }
 
-    partOfSpeech {
+    language {
       id
-
-      language {
-        id
-      }
     }
 
     isInUse
@@ -148,6 +140,7 @@ mutation DeleteInflectionTableMut($id: InflectionTableId!) {
 query AddDefinitionQuery($lang: LanguageId!) {
   language(id: $lang) {
     ...DefinitionFormPartsOfSpeechFragment
+    ...DefinitionFormInflectionTablesFragment
   }
 }
 
@@ -216,6 +209,7 @@ query EditDefinitionQuery($id: DefinitionId!) {
     language {
       id
       ...DefinitionFormPartsOfSpeechFragment
+      ...DefinitionFormInflectionTablesFragment
     }
   }
 }

--- a/packages/app/src/renderer/panels/query.ts
+++ b/packages/app/src/renderer/panels/query.ts
@@ -235,7 +235,7 @@ export const DeletePartOfSpeechMut = "mutation DeletePartOfSpeechMut($id:PartOfS
   deletePartOfSpeech: boolean | null;
 }>;
 
-export const AddInflectionTableMut = "mutation AddInflectionTableMut($data:NewInflectionTableInput!){addInflectionTable(data:$data){id,name,layout{id,stems...InflectionTableFragment}partOfSpeech{id,name,language{id,name}}}}fragment InflectionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,deriveLemma,displayName,hasCustomDisplayName}}...on InflectionTableHeaderCell{headerText}}}}" as Mutation<{
+export const AddInflectionTableMut = "mutation AddInflectionTableMut($data:NewInflectionTableInput!){addInflectionTable(data:$data){id,name,layout{id,stems...InflectionTableFragment}language{id,name}}}fragment InflectionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,deriveLemma,displayName,hasCustomDisplayName}}...on InflectionTableHeaderCell{headerText}}}}" as Mutation<{
   data: NewInflectionTableInput;
 }, {
   addInflectionTable: {
@@ -262,18 +262,14 @@ export const AddInflectionTableMut = "mutation AddInflectionTableMut($data:NewIn
         })[];
       }[];
     };
-    partOfSpeech: {
-      id: PartOfSpeechId;
+    language: {
+      id: LanguageId;
       name: string;
-      language: {
-        id: LanguageId;
-        name: string;
-      };
     };
   } | null;
 }>;
 
-export const EditInflectionTableQuery = "query EditInflectionTableQuery($id:InflectionTableId!){inflectionTable(id:$id){id,name,layout{isInUse...InflectionTableFragment}partOfSpeech{id,language{id}}isInUse,usedByDefinitions{page{totalCount}}}}fragment InflectionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,deriveLemma,displayName,hasCustomDisplayName}}...on InflectionTableHeaderCell{headerText}}}}" as Query<{
+export const EditInflectionTableQuery = "query EditInflectionTableQuery($id:InflectionTableId!){inflectionTable(id:$id){id,name,layout{isInUse...InflectionTableFragment}language{id}isInUse,usedByDefinitions{page{totalCount}}}}fragment InflectionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,deriveLemma,displayName,hasCustomDisplayName}}...on InflectionTableHeaderCell{headerText}}}}" as Query<{
   id: InflectionTableId;
 }, {
   inflectionTable: {
@@ -299,11 +295,8 @@ export const EditInflectionTableQuery = "query EditInflectionTableQuery($id:Infl
         })[];
       }[];
     };
-    partOfSpeech: {
-      id: PartOfSpeechId;
-      language: {
-        id: LanguageId;
-      };
+    language: {
+      id: LanguageId;
     };
     isInUse: boolean;
     usedByDefinitions: {
@@ -329,36 +322,36 @@ export const DeleteInflectionTableMut = "mutation DeleteInflectionTableMut($id:I
   deleteInflectionTable: boolean | null;
 }>;
 
-export const AddDefinitionQuery = "query AddDefinitionQuery($lang:LanguageId!){language(id:$lang){...DefinitionFormPartsOfSpeechFragment}}fragment DefinitionFormPartsOfSpeechFragment on Language{partsOfSpeech{id,name,inflectionTables{id,name,layout{id,stems...DefinitionTableFragment}}}}fragment DefinitionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}" as Query<{
+export const AddDefinitionQuery = "query AddDefinitionQuery($lang:LanguageId!){language(id:$lang){...DefinitionFormPartsOfSpeechFragment...DefinitionFormInflectionTablesFragment}}fragment DefinitionFormPartsOfSpeechFragment on Language{partsOfSpeech{id,name}}fragment DefinitionFormInflectionTablesFragment on Language{inflectionTables{id,name,layout{id,stems...DefinitionTableFragment}}}fragment DefinitionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}" as Query<{
   lang: LanguageId;
 }, {
   language: {
     partsOfSpeech: {
       id: PartOfSpeechId;
       name: string;
-      inflectionTables: {
-        id: InflectionTableId;
-        name: string;
-        layout: {
-          id: InflectionTableLayoutId;
-          stems: string[];
-          rows: {
-            cells: ({
-              rowSpan: number;
-              columnSpan: number;
-              inflectedForm: {
-                id: InflectedFormId;
-                inflectionPattern: string;
-                displayName: string;
-              };
-            } | {
-              rowSpan: number;
-              columnSpan: number;
-              headerText: string;
-            })[];
-          }[];
-        };
-      }[];
+    }[];
+    inflectionTables: {
+      id: InflectionTableId;
+      name: string;
+      layout: {
+        id: InflectionTableLayoutId;
+        stems: string[];
+        rows: {
+          cells: ({
+            rowSpan: number;
+            columnSpan: number;
+            inflectedForm: {
+              id: InflectedFormId;
+              inflectionPattern: string;
+              displayName: string;
+            };
+          } | {
+            rowSpan: number;
+            columnSpan: number;
+            headerText: string;
+          })[];
+        }[];
+      };
     }[];
   } | null;
 }>;
@@ -439,7 +432,7 @@ export const AddDefinitionMut = "mutation AddDefinitionMut($data:NewDefinitionIn
   } | null;
 }>;
 
-export const EditDefinitionQuery = "query EditDefinitionQuery($id:DefinitionId!){definition(id:$id){id,term,partOfSpeech{id}description{...RichTextBlockFragment}stems{name,value}inflectionTables{id,caption{inlines{...RichTextFragment}}customForms{inflectedForm{id}value}inflectionTable{id}inflectionTableLayout{id,isCurrent,stems...DefinitionTableFragment}}tags{name}language{id...DefinitionFormPartsOfSpeechFragment}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}fragment DefinitionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}fragment DefinitionFormPartsOfSpeechFragment on Language{partsOfSpeech{id,name,inflectionTables{id,name,layout{id,stems...DefinitionTableFragment}}}}" as Query<{
+export const EditDefinitionQuery = "query EditDefinitionQuery($id:DefinitionId!){definition(id:$id){id,term,partOfSpeech{id}description{...RichTextBlockFragment}stems{name,value}inflectionTables{id,caption{inlines{...RichTextFragment}}customForms{inflectedForm{id}value}inflectionTable{id}inflectionTableLayout{id,isCurrent,stems...DefinitionTableFragment}}tags{name}language{id...DefinitionFormPartsOfSpeechFragment...DefinitionFormInflectionTablesFragment}}}fragment RichTextBlockFragment on BlockElement{kind,level,inlines{__typename...RichTextFragment...RichLinkFragment}}fragment RichTextFragment on FormattedText{text,bold,italic,underline,strikethrough,subscript,superscript}fragment RichLinkFragment on LinkInline{linkTarget,internalLinkTarget{__typename...on LanguageLinkTarget{language{id,name}}...on LemmaLinkTarget{lemma{id,term,language{id,name}}}...on DefinitionLinkTarget{definition{id,term,language{id,name}}}...on PartOfSpeechLinkTarget{partOfSpeech{id,name,language{id,name}}}}inlines{...RichTextFragment}}fragment DefinitionTableFragment on InflectionTableLayout{rows{cells{rowSpan,columnSpan...on InflectionTableDataCell{inflectedForm{id,inflectionPattern,displayName}}...on InflectionTableHeaderCell{headerText}}}}fragment DefinitionFormPartsOfSpeechFragment on Language{partsOfSpeech{id,name}}fragment DefinitionFormInflectionTablesFragment on Language{inflectionTables{id,name,layout{id,stems...DefinitionTableFragment}}}" as Query<{
   id: DefinitionId;
 }, {
   definition: {
@@ -566,29 +559,29 @@ export const EditDefinitionQuery = "query EditDefinitionQuery($id:DefinitionId!)
       partsOfSpeech: {
         id: PartOfSpeechId;
         name: string;
-        inflectionTables: {
-          id: InflectionTableId;
-          name: string;
-          layout: {
-            id: InflectionTableLayoutId;
-            stems: string[];
-            rows: {
-              cells: ({
-                rowSpan: number;
-                columnSpan: number;
-                inflectedForm: {
-                  id: InflectedFormId;
-                  inflectionPattern: string;
-                  displayName: string;
-                };
-              } | {
-                rowSpan: number;
-                columnSpan: number;
-                headerText: string;
-              })[];
-            }[];
-          };
-        }[];
+      }[];
+      inflectionTables: {
+        id: InflectionTableId;
+        name: string;
+        layout: {
+          id: InflectionTableLayoutId;
+          stems: string[];
+          rows: {
+            cells: ({
+              rowSpan: number;
+              columnSpan: number;
+              inflectedForm: {
+                id: InflectedFormId;
+                inflectionPattern: string;
+                displayName: string;
+              };
+            } | {
+              rowSpan: number;
+              columnSpan: number;
+              headerText: string;
+            })[];
+          }[];
+        };
       }[];
     };
   } | null;

--- a/packages/server/src/database/schema/index.ts
+++ b/packages/server/src/database/schema/index.ts
@@ -18,11 +18,10 @@ const tables: readonly TableSchema[] = [
     commands: [`
       create table schema_info (
         -- The metadata key.
-        name text not null collate binary,
+        name text not null primary key collate binary,
         -- The metadata value.
-        value text not null collate binary,
-        primary key (name)
-      )`,
+        value text not null collate binary
+      ) without rowid`,
     ],
   },
 
@@ -128,8 +127,8 @@ const tables: readonly TableSchema[] = [
     commands: [`
       create table inflection_tables (
         id integer not null primary key,
-        -- The parent part of speech.
-        part_of_speech_id integer not null,
+        -- The parent language.
+        language_id integer not null,
         -- The date and time the inflection table was created, as the number of
         -- milliseconds since midnight 1 January, 1970, UTC.
         time_created integer not null,
@@ -139,11 +138,11 @@ const tables: readonly TableSchema[] = [
         -- The name of the inflection table, shown in admin UIs.
         name text not null collate unicode,
 
-        foreign key (part_of_speech_id)
-          references parts_of_speech
+        foreign key (language_id)
+          references languages
           on delete cascade
       )`,
-      `create unique index \`inflection_tables(part_of_speech_id,name)\` on inflection_tables(part_of_speech_id, name)`,
+      `create unique index \`inflection_tables(language_id,name)\` on inflection_tables(language_id, name)`,
       `create index \`inflection_tables(time_created)\` on inflection_tables(time_created)`,
       `create index \`inflection_tables(time_updated)\` on inflection_tables(time_updated)`,
     ],
@@ -425,7 +424,7 @@ const tables: readonly TableSchema[] = [
         foreign key (tag_id)
           references tags
           on delete restrict
-      )`,
+      ) without rowid`,
       `create index \`definition_tags(tag_id)\` on definition_tags(tag_id)`,
     ],
   },
@@ -460,7 +459,7 @@ const tables: readonly TableSchema[] = [
         foreign key (inflected_form_id)
           references inflected_forms
           on delete restrict
-      )`,
+      ) without rowid`,
       `create index \`derived_definitions(original_definition_id)\` on derived_definitions(original_definition_id)`,
       `create index \`derived_definitions(inflected_form_id)\` on derived_definitions(inflected_form_id)`,
     ],
@@ -474,10 +473,9 @@ const tables: readonly TableSchema[] = [
     name: 'tags',
     commands: [`
       create table tags (
-        id integer not null,
+        id integer not null primary key,
         -- The name of the tag.
-        name text not null collate unicode,
-        primary key (id)
+        name text not null collate unicode
       )`,
       `create unique index \`tags(name)\` on tags(name)`,
     ],

--- a/packages/server/src/event.ts
+++ b/packages/server/src/event.ts
@@ -152,10 +152,6 @@ export interface PartOfSpeechEvent extends BaseEvent<'partOfSpeech'> {
 export interface InflectionTableEvent extends BaseEvent<'inflectionTable'> {
   /** The ID of the inflection table. */
   readonly id: number;
-  /**
-   * The ID of the part of speech that the inflection table belongs/belonged to.
-   */
-  readonly partOfSpeechId: number;
   /** The ID of the language that the inflection table belongs/belonged to. */
   readonly languageId: number;
 }

--- a/packages/server/src/graphql/resolvers/inflection-table.ts
+++ b/packages/server/src/graphql/resolvers/inflection-table.ts
@@ -4,7 +4,7 @@ import {
   InflectionTableLayout as InflectionTableLayoutModel,
   InflectedForm as InflectedFormModel,
   Definition,
-  PartOfSpeech,
+  Language,
   InflectionTableRow,
   InflectionTableLayoutRow,
   InflectedFormRow,
@@ -34,7 +34,7 @@ const InflectionTable: ResolversFor<InflectionTableType, InflectionTableRow> = {
   oldLayouts: (p, {page}, {db}, info) =>
     InflectionTableLayoutModel.allOldByTable(db, p.id, page, info),
 
-  partOfSpeech: (p, _args, {db}) => PartOfSpeech.byId(db, p.part_of_speech_id),
+  language: (p, _args, {db}) => Language.byId(db, p.language_id),
 
   isInUse: (p, _args, {db}) => Definition.anyUsesInflectionTable(db, p.id),
 

--- a/packages/server/src/graphql/resolvers/language.ts
+++ b/packages/server/src/graphql/resolvers/language.ts
@@ -5,6 +5,7 @@ import {
   Description,
   Definition,
   PartOfSpeech,
+  InflectionTable,
   Lemma,
   Tag,
   SearchIndex,
@@ -34,6 +35,11 @@ const Language: ResolversFor<LanguageType, LanguageRow> = {
   partsOfSpeech: (p, _args, {db}) => PartOfSpeech.allByLanguage(db, p.id),
 
   partOfSpeechByName: (p, {name}, {db}) => PartOfSpeech.byName(db, p.id, name),
+
+  inflectionTables: (p, _args, {db}) => InflectionTable.allByLanguage(db, p.id),
+
+  inflectionTableByName: (p, {name}, {db}) =>
+    InflectionTable.byName(db, p.id, name),
 
   lemmaCount: p => p.lemma_count,
 

--- a/packages/server/src/graphql/resolvers/part-of-speech.ts
+++ b/packages/server/src/graphql/resolvers/part-of-speech.ts
@@ -2,7 +2,6 @@ import {
   PartOfSpeech as PartOfSpeechModel,
   PartOfSpeechStats as PartOfSpeechStatsModel,
   PartOfSpeechMut,
-  InflectionTable,
   Language,
   Definition,
   PartOfSpeechRow,
@@ -20,12 +19,6 @@ import {mutator} from '../helpers';
 import {ResolversFor, Mutators} from './types';
 
 const PartOfSpeech: ResolversFor<PartOfSpeechType, PartOfSpeechRow> = {
-  inflectionTables: (p, _args, {db}) =>
-    InflectionTable.allByPartOfSpeech(db, p.id),
-
-  inflectionTableByName: (p, {name}, {db}) =>
-    InflectionTable.byName(db, p.id, name),
-
   language: (p, _args, {db}) => Language.byId(db, p.language_id),
 
   isInUse: (p, _args, {db}) => Definition.anyUsesPartOfSpeech(db, p.id),
@@ -44,8 +37,6 @@ const PartOfSpeechStats: ResolversFor<
   PartOfSpeechStatsType,
   PartOfSpeechStatsRow
 > = {
-  inflectionTableCount: p => p.inflection_table_count,
-
   definitionCount: p => p.definition_count,
 };
 

--- a/packages/server/src/model/definition/table-mut.ts
+++ b/packages/server/src/model/definition/table-mut.ts
@@ -5,7 +5,7 @@ import {
   InflectionTableId,
   InflectionTableLayoutId,
   InflectedFormId,
-  PartOfSpeechId,
+  LanguageId,
   NewDefinitionInflectionTableInput,
   EditDefinitionInflectionTableInput,
 } from '../../graphql';
@@ -33,7 +33,7 @@ export type DefinitionData = {
   id: DefinitionId;
   term: string;
   stemMap: Map<string, string>;
-  partOfSpeechId: PartOfSpeechId;
+  languageId: LanguageId;
 };
 
 type ValidateInflectionTableResult = {
@@ -56,7 +56,7 @@ const DefinitionInflectionTableMut = {
     } = await this.validateInflectionTableId(
       db,
       inflectionTableId,
-      definition.partOfSpeechId
+      definition.languageId
     );
     const finalCaption = validateTableCaption(caption);
 
@@ -116,7 +116,7 @@ const DefinitionInflectionTableMut = {
     const {currentLayout} = await this.validateInflectionTableId(
       db,
       table.inflection_table_id,
-      definition.partOfSpeechId
+      definition.languageId
     );
 
     let tableLayout = await InflectionTableLayout.byIdRequired(
@@ -165,16 +165,16 @@ const DefinitionInflectionTableMut = {
   async validateInflectionTableId(
     db: DataWriter,
     inflectionTableId: InflectionTableId,
-    partOfSpeechId: PartOfSpeechId
+    languageId: LanguageId
   ): Promise<ValidateInflectionTableResult> {
     const inflectionTable = await InflectionTable.byIdRequired(
       db,
       inflectionTableId,
       'inflectionTableId'
     );
-    if (inflectionTable.part_of_speech_id !== partOfSpeechId) {
+    if (inflectionTable.language_id !== languageId) {
       throw new UserInputError(
-        `Inflection table ${inflectionTable.id} belongs to the wrong part of speech`,
+        `Inflection table ${inflectionTable.id} belongs to the wrong language`,
         {invalidArgs: ['inflectionTableId']}
       );
     }

--- a/packages/server/src/model/inflection-table/model.ts
+++ b/packages/server/src/model/inflection-table/model.ts
@@ -2,10 +2,10 @@ import {GraphQLResolveInfo} from 'graphql';
 
 import {DataReader} from '../../database';
 import {
-  PartOfSpeechId,
   InflectionTableId,
   InflectionTableLayoutId,
   InflectedFormId,
+  LanguageId,
   PageParams,
   validatePageParams,
   LayoutVersionFilter,
@@ -24,7 +24,7 @@ import {
 
 const InflectionTable = {
   byIdKey: 'InflectionTable.byId',
-  allByPartOfSpeechKey: 'InflectionTable.allByPartOfSpeechKey',
+  allByLanguageKey: 'InflectionTable.allByLanguageKey',
   defaultPagination: {
     page: 0,
     perPage: 50,
@@ -64,32 +64,32 @@ const InflectionTable = {
 
   byName(
     db: DataReader,
-    partOfSpeechId: PartOfSpeechId,
+    languageId: LanguageId,
     name: string
   ): InflectionTableRow | null {
     return db.get`
       select *
       from inflection_tables
-      where part_of_speech_id = ${partOfSpeechId}
+      where language_id = ${languageId}
         and name = ${name}
     `;
   },
 
-  allByPartOfSpeech(
+  allByLanguage(
     db: DataReader,
-    partOfSpeechId: PartOfSpeechId
+    languageId: LanguageId
   ): Promise<InflectionTableRow[]> {
     return db.batchOneToMany(
-      this.allByPartOfSpeechKey,
-      partOfSpeechId,
-      (db, partOfSpeechIds) =>
+      this.allByLanguageKey,
+      languageId,
+      (db, languageIds) =>
         db.all<InflectionTableRow>`
           select *
           from inflection_tables
-          where part_of_speech_id in (${partOfSpeechIds})
-          order by part_of_speech_id, name
+          where language_id in (${languageIds})
+          order by language_id, name
         `,
-      row => row.part_of_speech_id
+      row => row.language_id
     );
   },
 

--- a/packages/server/src/model/inflection-table/types.ts
+++ b/packages/server/src/model/inflection-table/types.ts
@@ -2,13 +2,13 @@ import {
   InflectionTableId,
   InflectionTableLayoutId,
   InflectedFormId,
-  PartOfSpeechId,
+  LanguageId,
   DefinitionId,
 } from '../../graphql';
 
 export type InflectionTableRow = {
   id: InflectionTableId;
-  part_of_speech_id: PartOfSpeechId;
+  language_id: LanguageId;
   time_created: number;
   time_updated: number;
   name: string;

--- a/packages/server/src/model/inflection-table/validators.ts
+++ b/packages/server/src/model/inflection-table/validators.ts
@@ -1,14 +1,14 @@
 import {normalizePattern} from '@condict/inflect';
 
 import {DataReader} from '../../database';
-import {InflectionTableId, PartOfSpeechId} from '../../graphql';
+import {InflectionTableId, LanguageId} from '../../graphql';
 
 import validator, {minLength, unique} from '../validator';
 
 export const validateName = (
   db: DataReader,
   currentId: InflectionTableId | null,
-  partOfSpeechId: PartOfSpeechId,
+  languageId: LanguageId,
   value: string
 ): string =>
   validator<string>('name')
@@ -21,7 +21,7 @@ export const validateName = (
           select id
           from inflection_tables
           where name = ${name}
-            and part_of_speech_id = ${partOfSpeechId}
+            and language_id = ${languageId}
         `;
         return row ? row.id : null;
       },

--- a/packages/server/src/model/lemma/filter.ts
+++ b/packages/server/src/model/lemma/filter.ts
@@ -71,6 +71,7 @@ const EmptySql = new RawSql('', []);
 
 export const buildOwnDefinitionsSource = (
   db: DataReader,
+  alias: RawSql,
   joinType: 'left' | 'inner',
   filter: LemmaFilter
 ): RawSql => {
@@ -110,17 +111,17 @@ export const buildOwnDefinitionsSource = (
       ${filter.inflectsLike || filter.withTags
         ? db.raw`group by d.lemma_id`
         : EmptySql}
-    ) d on
-      d.lemma_id = l.id
       ${needsMatchingTagCount
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        ? db.raw`and d.tag_count = ${filter.withTags!.length}`
+        ? db.raw`having tag_count = ${filter.withTags!.length}`
         : EmptySql}
+    ) ${alias} on ${alias}.lemma_id = l.id
   `;
 };
 
 export const buildDerivedDefinitionsSource = (
   db: DataReader,
+  alias: RawSql,
   joinType: 'left' | 'inner',
   filter: LemmaFilter
 ): RawSql => {
@@ -150,6 +151,6 @@ export const buildDerivedDefinitionsSource = (
       ${filter.inPartsOfSpeech || filter.inflectsLike
         ? db.raw`group by dd.lemma_id`
         : EmptySql}
-    ) dd on dd.lemma_id = l.id
+    ) ${alias} on ${alias}.lemma_id = l.id
   `;
 };

--- a/packages/server/src/model/lemma/model.ts
+++ b/packages/server/src/model/lemma/model.ts
@@ -135,9 +135,12 @@ const Lemma = {
 
     const joinType = filter.kind === 'ALL_LEMMAS' ? 'left' : 'inner';
     const source = db.raw`
-      ${buildOwnDefinitionsSource(db, joinType, filter)}
-      ${buildDerivedDefinitionsSource(db, joinType, filter)}
+      ${buildOwnDefinitionsSource(db, db.raw`d`, joinType, filter)}
+      ${buildDerivedDefinitionsSource(db, db.raw`dd`, joinType, filter)}
     `;
+    const whereAnyMatch = filter.kind === 'ALL_LEMMAS'
+      ? db.raw`and (d.lemma_id is not null or dd.lemma_id is not null)`
+      : db.raw``;
     return paginate(
       validatePageParams(page ?? this.defaultPagination, this.maxPerPage),
       () => {
@@ -146,6 +149,7 @@ const Lemma = {
           from lemmas l
           ${source}
           where l.language_id = ${languageId}
+            ${whereAnyMatch}
         `;
         return total;
       },
@@ -154,6 +158,7 @@ const Lemma = {
         from lemmas l
         ${source}
         where l.language_id = ${languageId}
+          ${whereAnyMatch}
         order by l.term
         limit ${limit} offset ${offset}
       `,

--- a/packages/server/src/model/part-of-speech/model.ts
+++ b/packages/server/src/model/part-of-speech/model.ts
@@ -81,10 +81,8 @@ const PartOfSpeechStats = {
       (db, ids) => db.all<PartOfSpeechStatsRow>`
         select
           pos.id as id,
-          count(distinct it.id) as inflection_table_count,
           count(distinct d.id) as definition_count
         from parts_of_speech pos
-        left join inflection_tables it on it.part_of_speech_id = pos.id
         left join definitions d on d.part_of_speech_id = pos.id
         where pos.id in (${ids})
         group by pos.id


### PR DESCRIPTION
This PR makes inflection tables independent of parts of speech. They now reside directly under languages.

My reasoning:

The original idea was as follows: only verbs can be conjugated like verbs, so it doesn't make sense to show verbal inflection tables for nouns. Likewise, verbs can't receive nominal declension, so why would you make it possible to add such tables to a verb? Similar arguments apply to other parts of speech.

In practice, however, languages are not so straightforward. There may be languages in which adjectives can behave like verbs or nouns depending on context, so it makes sense for them to both conjugate and decline. Now the inability to add verb tables to an adjective potentially forces you to duplicate tables in your dictionary.

By making inflection tables a top-level resource under languages, we do end up shifting some of the burden onto the user, who now has to structure things themself, but we also give them the power to do as they please. I believe this change to be ultimately beneficial.